### PR TITLE
Bootstrap EPOCH planning docs, native runtime stance, and first execution slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ Calendar and scheduling surface for the broader KHYRON and SYMBIOSIS suite.
 ## Current execution order
 
 1. Lock the product boundary.
-2. Define the first shippable EPOCH slice.
-3. Track integrations only after the boundary and v1 slice are explicit.
+2. Lock the runtime and packaging stance.
+3. Define the first shippable EPOCH slice.
+4. Track integrations only after the boundary, runtime stance, and v1 slice are explicit.
 
 ## Current planning artifacts
 
 - `docs/product-boundary.md`
+- `docs/runtime-and-packaging.md`
 - `docs/v1-minimal-scheduling-surface.md`
 
 ## Initial product intent
@@ -26,8 +28,18 @@ EPOCH is not trying to solve every adjacent suite concern in its first pass. Dee
 integration into SYNAPSIS, SYMBIOSIS, ANVIL, NEXUS, and other surfaces should
 follow a stable EPOCH boundary instead of defining it.
 
+## Implementation stance
+
+- Native C is the default implementation language for EPOCH.
+- Avalonia is the desktop host and UI surface.
+- The boundary between the Avalonia host and the EPOCH core should be explicit
+  native C interop instead of managed business logic.
+- C# should be limited to the thin host, binding, and interop glue that
+  Avalonia or platform integration requires.
+
 ## Near-term goal
 
 The immediate goal is to define a minimal but executable scheduling product
-contract, then deliver one narrow v1 surface that proves EPOCH can own
-scheduling without premature coupling to the rest of the suite.
+contract, lock the native-runtime stance, then deliver one narrow v1 surface
+that proves EPOCH can own scheduling without premature coupling to the rest of
+the suite or unnecessary managed implementation spread.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # EPOCH
+
 Calendar and scheduling surface for the broader KHYRON and SYMBIOSIS suite.
+
+## Current execution order
+
+1. Lock the product boundary.
+2. Define the first shippable EPOCH slice.
+3. Track integrations only after the boundary and v1 slice are explicit.
+
+## Current planning artifacts
+
+- `docs/product-boundary.md`
+- `docs/v1-minimal-scheduling-surface.md`
+
+## Initial product intent
+
+EPOCH is the suite surface responsible for calendar- and schedule-shaped work:
+
+- time-based objects such as events and schedule entries
+- user-facing planning and viewing flows
+- timezone-aware scheduling behavior
+- the contract for future reminders, recurrence, and availability work
+
+EPOCH is not trying to solve every adjacent suite concern in its first pass. Deep
+integration into SYNAPSIS, SYMBIOSIS, ANVIL, NEXUS, and other surfaces should
+follow a stable EPOCH boundary instead of defining it.
+
+## Near-term goal
+
+The immediate goal is to define a minimal but executable scheduling product
+contract, then deliver one narrow v1 surface that proves EPOCH can own
+scheduling without premature coupling to the rest of the suite.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,73 @@
 # EPOCH
 
-Calendar and scheduling surface for the broader KHYRON and SYMBIOSIS suite.
+Scheduling, calendar, and operating-administration surface for the broader
+KHYRON, SYMBIOSIS, and CITADEL suite.
 
 ## Current execution order
 
-1. Lock the product boundary.
-2. Lock the runtime and packaging stance.
-3. Define the first shippable EPOCH slice.
-4. Track integrations only after the boundary, runtime stance, and v1 slice are explicit.
+1. Lock the expanded product boundary.
+2. Preserve the native runtime and packaging stance.
+3. Define the first shippable operating slice.
+4. Track integrations by phase so urgent education-revenue work does not
+   collapse into unbounded platform scope.
 
 ## Current planning artifacts
 
 - `docs/product-boundary.md`
 - `docs/runtime-and-packaging.md`
 - `docs/v1-minimal-scheduling-surface.md`
+- `docs/education-operating-platform-boundary.md`
+- `docs/first-commercial-slice-checklist.md`
 
 ## Initial product intent
 
-EPOCH is the suite surface responsible for calendar- and schedule-shaped work:
+EPOCH is the suite surface responsible for time-, calendar-, schedule-, and
+operations-shaped work:
 
 - time-based objects such as events and schedule entries
 - user-facing planning and viewing flows
 - timezone-aware scheduling behavior
 - the contract for future reminders, recurrence, and availability work
+- internal administration over programs, classes, requests, submissions, and
+  review cycles when those workflows are schedule-bound
+- external student/customer notification, update, tracking, request, and
+  submission surfaces when they depend on schedule state
+- MONITOR-grade operational visibility for EPOCH lanes, following the HERMES
+  MONITOR capability pattern as the parity target
 
-EPOCH is not trying to solve every adjacent suite concern in its first pass. Deep
-integration into SYNAPSIS, SYMBIOSIS, ANVIL, NEXUS, and other surfaces should
-follow a stable EPOCH boundary instead of defining it.
+The immediate commercial wedge is an education operating platform that supports
+premium exam/writing/test-prep offers with less live-class labor: cohorts,
+submission workflows, progress tracking, request handling, and professional
+web-facing conversion surfaces.
+
+EPOCH is not trying to solve every adjacent suite concern in one pass. Deep
+integration into SYMBIOSIS, FURYOKU, ANVIL, NEXUS, LIBRARY, and other CITADEL
+surfaces should follow a stable phased EPOCH boundary instead of defining it by
+accident.
+
+## First commercial operating lane
+
+The first revenue-facing lane should support:
+
+- premium adult and serious-student education services
+- EIKEN 5-1 and later TOEIC, IELTS, TOEFL, school writing, university writing,
+  and professional English tracks
+- under-19 compatibility assessment before acceptance, or higher-touch pricing
+  when younger students are accepted
+- fewer live classes by default, with cohorts, submissions, structured feedback,
+  and progress reporting doing more of the work
+- professional public website copy and intake paths that do not lead with AI
+  terminology in Japan-facing messaging
+- adjacent revenue services such as consulting, tech support, clerical/admin,
+  database, CRM, management-system, and automation support
+
+## ARA revenue direction
+
+EPOCH should also support the Agentic Response Array revenue model: MONITOR,
+SYMBIOSIS, FURYOKU, and other CITADEL projects should be able to create,
+schedule, track, operate, and report revenue-producing work with minimal manual
+input from Jack. EPOCH owns the schedule/admin layer for that future loop; the
+agent/control-plane behavior remains owned by the appropriate ARA projects.
 
 ## Implementation stance
 
@@ -39,7 +80,9 @@ follow a stable EPOCH boundary instead of defining it.
 
 ## Near-term goal
 
-The immediate goal is to define a minimal but executable scheduling product
-contract, lock the native-runtime stance, then deliver one narrow v1 surface
-that proves EPOCH can own scheduling without premature coupling to the rest of
-the suite or unnecessary managed implementation spread.
+The immediate goal is to replace the narrow calendar-only bootstrap with a
+minimal but executable operating product contract: a scheduling core, a class
+and submission administration surface, a HERMES-style monitor parity target, and
+a public website/intake path. This should prove EPOCH can own schedule-bound
+operations without premature coupling to every CITADEL integration or
+unnecessary managed implementation spread.

--- a/docs/education-operating-platform-boundary.md
+++ b/docs/education-operating-platform-boundary.md
@@ -1,0 +1,106 @@
+# Education Operating Platform Boundary
+
+## Purpose
+
+This document defines the first commercial operating lane for EPOCH: a premium,
+professional education and service-delivery platform that reduces manual labor
+by coordinating classes, cohorts, submissions, reviews, requests, notifications,
+and progress tracking.
+
+The platform should support education revenue first, then generalize into ARA
+revenue operations for consulting, tech support, clerical/admin, database, CRM,
+management-system, and automation services.
+
+## Positioning rules
+
+- Lead Japan-facing offers with outcomes, structure, teacher-reviewed guidance,
+  scheduling reliability, progress tracking, and professional support.
+- Do not lead with AI terminology in English-education marketing.
+- Do not sell generic tutoring as the primary product; sell exam/result
+  coaching, structured writing review, cohort labs, submission packs, and
+  managed progress.
+- Prefer adults and serious students. Students under 19 should require
+  compatibility assessment, guardian agreement, and either a limited accepted
+  track or higher-touch pricing.
+- Keep 1:1 live teaching premium and scarce. Use cohorts, submissions, and
+  asynchronous review to reduce labor.
+
+## Education products EPOCH must support
+
+- EIKEN 5 through 1 tracks, with writing/interview/test-prep emphasis where
+  relevant.
+- TOEIC, IELTS, TOEFL, school/university writing, business English, and
+  professional communication tracks as later catalog entries.
+- Paid diagnostics.
+- Submission review packs.
+- Cohort labs with class sessions and submission windows.
+- Premium exam sprints.
+- Subscription study-material and strategy access after the operating workflow
+  proves demand.
+
+## Core workflow
+
+1. Prospect enters through the website or direct intake.
+2. Intake records age, goal, current level, schedule, compatibility, and urgency.
+3. EPOCH creates diagnostic, class, submission, or consultation schedule items.
+4. Student/customer submits work or request.
+5. Internal admin view shows review deadlines, overdue work, and next actions.
+6. Provider returns feedback, update, or next assignment.
+7. External view shows the student/customer what is due, submitted, returned, or
+   requested.
+8. EPOCH MONITOR records lane health, queue state, risks, and receipts.
+
+The first implementable checklist lives in
+`docs/first-commercial-slice-checklist.md`.
+
+## Website/platform requirements
+
+- Professional public landing page for education services.
+- Pricing and package pages that support premium positioning without founder
+  discount language.
+- Intake form for diagnostics, classes, submission packs, and consultations.
+- Student/customer portal for schedule, requests, submissions, and updates.
+- Admin portal for calendar, cohorts, queue, overdue items, and status.
+- Marketing pages for Japan-wide service first, then global expansion.
+- Content blocks for all-level EIKEN and later non-EIKEN test tracks.
+
+## EPOCH MONITOR parity target
+
+EPOCH MONITOR should follow the HERMES MONITOR capability pattern:
+
+- generated local monitor state
+- project/lane tree
+- Summary, Scope, Memory, Queue, Timeline, Risks, and Receipts sections
+- health indicators for overdue, blocked, stale, dirty, or awaiting-review work
+- visible route/page integration
+- safe local-first operation with public access denied unless access control is
+  explicitly verified
+
+The first parity pass should clone the capability model, not the exact HERMES
+domain wording. EPOCH names should describe scheduling, education operations,
+student/customer status, service requests, and revenue workflow health.
+
+## Revenue expansion surfaces
+
+EPOCH should be able to schedule and administer:
+
+- education products
+- consulting sessions
+- tech support
+- clerical/admin work
+- database/CRM/management-system setup and maintenance
+- business process documentation
+- automation and internal tooling projects
+- ARA-created service tasks that need tracking, follow-up, and revenue receipts
+
+## Explicit deferrals
+
+- Full payment processing.
+- Public automated notification delivery.
+- Production authentication.
+- Deep LIBRARY persistence.
+- Full HERMES-equivalent autopilot behavior.
+- Full global advertising automation.
+- Full LMS curriculum authoring.
+
+These are planned phases, not v1 blockers.

--- a/docs/first-commercial-slice-checklist.md
+++ b/docs/first-commercial-slice-checklist.md
@@ -1,0 +1,62 @@
+# First Commercial Slice Checklist
+
+## Goal
+
+Define the first implementable EPOCH slice for revenue-supporting education and
+service operations without waiting for every future CITADEL integration.
+
+## Required screens or surfaces
+
+- Public professional offer page.
+- Intake path for diagnostics, cohorts, submissions, consultations, and service
+  requests.
+- Internal schedule/admin view.
+- Student/customer status view or export-ready status page.
+- EPOCH MONITOR status page for queue, overdue, risk, and receipt visibility.
+
+## Required records
+
+- Lead or prospect.
+- Student/customer.
+- Program or service track.
+- Cohort or engagement.
+- Session.
+- Assignment or service request.
+- Submission or deliverable.
+- Review/feedback item.
+- Follow-up item.
+- Receipt or outcome note.
+
+## Required operating states
+
+- planned
+- waiting
+- submitted
+- reviewing
+- returned
+- overdue
+- blocked
+- canceled
+- complete
+
+## Required revenue-supporting behaviors
+
+- Schedule a diagnostic, cohort class, consultation, or service call.
+- Create a submission or request window.
+- Record when work is submitted.
+- Record when review or feedback is returned.
+- Show internal next actions.
+- Show overdue submissions, reviews, and follow-ups.
+- Give the student/customer a clear status view.
+- Produce monitor-visible receipts for completed delivery.
+
+## Acceptance criteria
+
+- The first slice can administer at least one paid cohort or service engagement
+  from intake through returned feedback.
+- The provider can see today, upcoming, overdue, and blocked work.
+- A student/customer can see what is due, what was submitted, what was returned,
+  and what is next.
+- The monitor can summarize health without manually reading every record.
+- The slice does not depend on production payment, public notification delivery,
+  full authentication, or deep LIBRARY persistence.

--- a/docs/product-boundary.md
+++ b/docs/product-boundary.md
@@ -1,0 +1,47 @@
+# EPOCH Product Boundary
+
+## Purpose
+
+EPOCH is the calendar and scheduling surface for the broader KHYRON and
+SYMBIOSIS suite. It should own the model and user-facing surface of scheduling
+work without requiring immediate deep integration into every adjacent product.
+
+## EPOCH owns
+
+- event and schedule-entry primitives
+- timezone-aware date and time handling for scheduling workflows
+- calendar and schedule presentation surfaces
+- the contract for reminders, recurrence, and availability
+- the primary place where scheduling intent is created, reviewed, and updated
+
+## EPOCH does not own right now
+
+- full cross-suite orchestration
+- external calendar sync
+- complex resource booking
+- multi-party invitation and attendee workflows
+- notification delivery infrastructure outside the EPOCH contract itself
+
+## Relationship to adjacent products
+
+- `TEMPO` is the closest conceptual peer for time primitives and adjacent time UX.
+- `SYNAPSIS` is a likely shell and suite-placement surface.
+- `SYMBIOSIS` is a likely runtime and agent-facing integration surface.
+- `ANVIL` is a likely workflow and work-planning integration surface.
+- `NEXUS` is a likely communications and coordination integration surface.
+
+These relationships matter, but they should remain deferred integration planning
+until EPOCH has a stable boundary and a clear first slice.
+
+## Immediate boundary questions
+
+- What is the minimal event object EPOCH must own in v1?
+- Which scheduling actions must exist in the first shippable surface?
+- What reminder and recurrence behaviors need to be specified now versus later?
+- Which integrations are hard dependencies, and which are explicitly deferred?
+
+## Exit criteria for boundary lock
+
+- EPOCH has a clear ownership statement for scheduling.
+- The v1 surface is defined as a narrow execution slice.
+- Deferred integrations are recorded separately instead of pulled into v1.

--- a/docs/product-boundary.md
+++ b/docs/product-boundary.md
@@ -2,9 +2,15 @@
 
 ## Purpose
 
-EPOCH is the calendar and scheduling surface for the broader KHYRON and
-SYMBIOSIS suite. It should own the model and user-facing surface of scheduling
-work without requiring immediate deep integration into every adjacent product.
+EPOCH is the calendar, scheduling, and schedule-bound operating administration
+surface for the broader KHYRON, SYMBIOSIS, and CITADEL suite. It owns the model
+and user-facing surface of time-organized work without requiring immediate deep
+integration into every adjacent product.
+
+The current commercial pressure adds an education-platform wedge: EPOCH must be
+able to support classes, cohorts, student/customer requests, submissions,
+progress tracking, notifications, and professional public intake for premium
+education offers while preserving a reusable scheduling core.
 
 ## EPOCH owns
 
@@ -13,35 +19,93 @@ work without requiring immediate deep integration into every adjacent product.
 - calendar and schedule presentation surfaces
 - the contract for reminders, recurrence, and availability
 - the primary place where scheduling intent is created, reviewed, and updated
+- schedule-bound operating objects such as cohorts, sessions, submission
+  windows, review deadlines, request queues, and follow-up checkpoints
+- internal administration for schedule-dependent education and service delivery
+- external student/customer views for notification, update, tracking, request,
+  and submission workflows
+- EPOCH MONITOR visibility over schedule health, queue state, overdue work,
+  workload, review status, delivery risk, and lane history
+- a public website/intake surface when the site is directly feeding EPOCH
+  scheduling, onboarding, request, or submission workflows
 
 ## EPOCH does not own right now
 
-- full cross-suite orchestration
-- external calendar sync
-- complex resource booking
-- multi-party invitation and attendee workflows
+- full cross-suite orchestration or agentic decision-making
+- all education curriculum or pedagogical content as a separate knowledge domain
+- payment processing as a first-class finance system
+- external calendar sync beyond defining import/export and future integration
+  contracts
+- complex resource booking outside the first education/service operating lanes
+- generalized CRM, database, or helpdesk products that are not schedule-bound
 - notification delivery infrastructure outside the EPOCH contract itself
 
 ## Relationship to adjacent products
 
 - `TEMPO` is the closest conceptual peer for time primitives and adjacent time UX.
-- `SYNAPSIS` is a likely shell and suite-placement surface.
 - `SYMBIOSIS` is a likely runtime and agent-facing integration surface.
+- `FURYOKU` and `HERMES` are the monitor/autopilot pattern sources for EPOCH
+  MONITOR parity.
 - `ANVIL` is a likely workflow and work-planning integration surface.
 - `NEXUS` is a likely communications and coordination integration surface.
+- `LIBRARY` is the likely durable data/retrieval substrate when EPOCH needs
+  long-lived records or knowledge-linked history.
 
-These relationships matter, but they should remain deferred integration planning
-until EPOCH has a stable boundary and a clear first slice.
+These relationships matter, but they should be phased. EPOCH should not wait for
+every suite dependency before delivering its first commercial operating slice.
+
+## Phased boundary
+
+### Phase 0: Boundary reset
+
+Record the expanded EPOCH ownership model and explicitly separate owned,
+integrated, and deferred scope.
+
+### Phase 1: Education operating slice
+
+Support a premium education-service workflow with:
+
+- public website and intake path
+- adult/serious-student positioning with under-19 compatibility assessment or
+  higher-touch pricing
+- class/cohort/session calendar
+- assignment and submission windows
+- review and feedback deadlines
+- student/customer status tracking
+- internal admin dashboard for next actions, overdue items, and workload
+
+### Phase 2: EPOCH MONITOR parity
+
+Clone the HERMES MONITOR capability pattern into an EPOCH-specific monitor:
+
+- lane tree and status pages
+- sections for Summary, Scope, Memory, Queue, Timeline, Risks, and Receipts
+- health and overdue-state generation
+- visible project/menu integration
+- safe local-first operation with public exposure denied until access control is
+  explicitly configured
+
+### Phase 3: ARA revenue operations
+
+Use EPOCH to schedule, track, and report revenue-producing work created by ARA
+projects, including education, consulting, tech support, clerical/admin,
+database/CRM/management systems, and automation/service delivery.
 
 ## Immediate boundary questions
 
-- What is the minimal event object EPOCH must own in v1?
-- Which scheduling actions must exist in the first shippable surface?
-- What reminder and recurrence behaviors need to be specified now versus later?
+- What is the minimal schedule-bound operating object EPOCH must own in v1?
+- Which class/cohort/submission actions must exist in the first shippable
+  education operating surface?
+- Which HERMES MONITOR capabilities are cloned exactly, and which are renamed or
+  adapted for EPOCH?
+- Which public website/intake features are EPOCH-owned versus marketing/content
+  artifacts?
 - Which integrations are hard dependencies, and which are explicitly deferred?
 
 ## Exit criteria for boundary lock
 
 - EPOCH has a clear ownership statement for scheduling.
-- The v1 surface is defined as a narrow execution slice.
+- EPOCH has a clear ownership statement for schedule-bound operating
+  administration.
+- The v1 surface is defined as a narrow education/service operating slice.
 - Deferred integrations are recorded separately instead of pulled into v1.

--- a/docs/runtime-and-packaging.md
+++ b/docs/runtime-and-packaging.md
@@ -10,6 +10,9 @@ only where the host, UI framework, or platform integration makes it necessary.
 - Native C is the default implementation language.
 - Scheduling logic, data structures, validation, and state transitions should
   live in native C by default.
+- Schedule-bound operating logic for sessions, cohorts, submission windows,
+  review deadlines, queue state, and status transitions should also prefer the
+  native core when the behavior is reusable beyond one host.
 - Managed code should not become the primary home of EPOCH business rules.
 
 ## Avalonia role
@@ -19,6 +22,8 @@ only where the host, UI framework, or platform integration makes it necessary.
   concerns.
 - Avalonia should consume EPOCH through a deliberate interop boundary rather
   than by reimplementing the core scheduling model in C#.
+- Avalonia may host the first internal administration surface for calendars,
+  cohorts, submissions, overdue work, and EPOCH MONITOR status.
 
 ## Interop boundary
 
@@ -28,6 +33,9 @@ only where the host, UI framework, or platform integration makes it necessary.
   chatty object-shaped crossings.
 - Design the interop boundary so the native core can later be hosted by other
   shells without CLR coupling.
+- Public website, student/customer portal, and ARA service surfaces should
+  consume the same scheduling/operating contract rather than inventing separate
+  schedule state.
 
 ## C# is allowed where necessary
 
@@ -35,6 +43,9 @@ only where the host, UI framework, or platform integration makes it necessary.
 - XAML or Avalonia view code
 - platform-specific desktop integration that Avalonia expects in managed code
 - interop marshaling and native library loading
+- host-side rendering of internal dashboards and monitor pages
+- adapters to web/API surfaces before a more permanent cross-host boundary is
+  available
 
 ## C# is not the default place for
 
@@ -42,6 +53,8 @@ only where the host, UI framework, or platform integration makes it necessary.
 - recurrence evaluation
 - event mutation and validation logic
 - storage-neutral data contracts owned by the core runtime
+- cohort/session/submission/review state transitions that should remain shared
+  across desktop, web, monitor, and ARA service workflows
 
 ## Packaging direction
 
@@ -49,11 +62,18 @@ only where the host, UI framework, or platform integration makes it necessary.
 - Keep the native runtime independently testable outside the desktop shell.
 - Avoid taking runtime dependencies that force the core scheduling engine to
   live inside the CLR.
+- Package web/portal surfaces as consumers of EPOCH contracts, not as the
+  permanent source of scheduling truth.
+- Keep EPOCH MONITOR generation local-first until public access control and
+  exposure policy are explicitly verified.
 
 ## Implications for the first executable slice
 
-- The v1 scheduling surface should prove the native C core first.
+- The v1 operating surface should prove the native C core first for
+  schedule-bound objects and status transitions.
 - The Avalonia shell should stay thin and consume the native core via explicit
-  interop.
+  interop for internal administration.
+- A website or student/customer portal may be built sooner for revenue, but it
+  should be treated as a host/client surface over the EPOCH contract.
 - If logic must land in C# for host reasons, document the exception instead of
   letting it silently become the new default.

--- a/docs/runtime-and-packaging.md
+++ b/docs/runtime-and-packaging.md
@@ -1,0 +1,59 @@
+# EPOCH Runtime And Packaging Stance
+
+## Goal
+
+Keep EPOCH primarily native C while using Avalonia as the desktop shell and C#
+only where the host, UI framework, or platform integration makes it necessary.
+
+## Core stance
+
+- Native C is the default implementation language.
+- Scheduling logic, data structures, validation, and state transitions should
+  live in native C by default.
+- Managed code should not become the primary home of EPOCH business rules.
+
+## Avalonia role
+
+- Avalonia is the desktop application shell and UI surface.
+- Avalonia can own windowing, rendering, binding, and desktop-app lifecycle
+  concerns.
+- Avalonia should consume EPOCH through a deliberate interop boundary rather
+  than by reimplementing the core scheduling model in C#.
+
+## Interop boundary
+
+- Use a stable native C ABI between the EPOCH core and the Avalonia host.
+- Keep the interop surface coarse-grained and versionable.
+- Prefer plain structs, explicit handles, and predictable ownership rules over
+  chatty object-shaped crossings.
+- Design the interop boundary so the native core can later be hosted by other
+  shells without CLR coupling.
+
+## C# is allowed where necessary
+
+- Avalonia app bootstrap and application lifecycle
+- XAML or Avalonia view code
+- platform-specific desktop integration that Avalonia expects in managed code
+- interop marshaling and native library loading
+
+## C# is not the default place for
+
+- scheduling rules
+- recurrence evaluation
+- event mutation and validation logic
+- storage-neutral data contracts owned by the core runtime
+
+## Packaging direction
+
+- Package EPOCH as a native C core plus an Avalonia desktop host.
+- Keep the native runtime independently testable outside the desktop shell.
+- Avoid taking runtime dependencies that force the core scheduling engine to
+  live inside the CLR.
+
+## Implications for the first executable slice
+
+- The v1 scheduling surface should prove the native C core first.
+- The Avalonia shell should stay thin and consume the native core via explicit
+  interop.
+- If logic must land in C# for host reasons, document the exception instead of
+  letting it silently become the new default.

--- a/docs/v1-minimal-scheduling-surface.md
+++ b/docs/v1-minimal-scheduling-surface.md
@@ -1,0 +1,50 @@
+# EPOCH v1 Minimal Scheduling Surface
+
+## Goal
+
+Define the first shippable EPOCH slice as a narrow scheduling surface that
+proves product ownership before broader suite integrations are attempted.
+
+## v1 intent
+
+The first slice should support a user creating, viewing, and updating a simple
+scheduled item with explicit time boundaries and timezone-aware behavior.
+
+## Minimum contract
+
+- title
+- optional notes or description
+- start timestamp
+- end timestamp
+- timezone
+- status such as active or canceled
+
+## Minimum user-facing behaviors
+
+- create a schedule entry
+- view upcoming scheduled entries
+- edit the basic fields of an entry
+- cancel an entry without deleting historical intent
+
+## Explicitly deferred from this slice
+
+- recurring execution logic beyond documenting the future contract
+- reminder delivery systems
+- attendee and invitation workflows
+- external calendar synchronization
+- deep integrations with SYNAPSIS, SYMBIOSIS, ANVIL, NEXUS, or other suite
+  surfaces
+
+## Why this is the right first slice
+
+This slice is large enough to prove that EPOCH can own scheduling data and user
+flows, but small enough to avoid coupling v1 delivery to unresolved suite-wide
+dependencies.
+
+## Ready-for-implementation check
+
+The execution issue for this slice should only move into implementation after:
+
+- the product boundary is accepted
+- the minimum contract is not disputed
+- deferred integrations stay deferred

--- a/docs/v1-minimal-scheduling-surface.md
+++ b/docs/v1-minimal-scheduling-surface.md
@@ -1,14 +1,16 @@
-# EPOCH v1 Minimal Scheduling Surface
+# EPOCH v1 Minimal Operating Surface
 
 ## Goal
 
-Define the first shippable EPOCH slice as a narrow scheduling surface that
-proves product ownership before broader suite integrations are attempted.
+Define the first shippable EPOCH slice as a narrow scheduling and education
+operations surface that proves product ownership before broader suite
+integrations are attempted.
 
 ## v1 intent
 
-The first slice should support a user creating, viewing, and updating a simple
-scheduled item with explicit time boundaries and timezone-aware behavior.
+The first slice should support a provider creating, viewing, and updating
+schedule-bound education/service work with explicit time boundaries,
+timezone-aware behavior, and a submission/review loop.
 
 ## Implementation stance for v1
 
@@ -19,6 +21,8 @@ scheduled item with explicit time boundaries and timezone-aware behavior.
 
 ## Minimum contract
 
+### Schedule entry
+
 - title
 - optional notes or description
 - start timestamp
@@ -26,27 +30,48 @@ scheduled item with explicit time boundaries and timezone-aware behavior.
 - timezone
 - status such as active or canceled
 
+### Operating entry
+
+- type such as class, cohort session, diagnostic, assignment window, submission
+  deadline, review deadline, request, or follow-up
+- linked student/customer/cohort identifier
+- owner or responsible reviewer
+- internal status such as planned, waiting, submitted, reviewing, returned,
+  overdue, canceled, or complete
+- external visibility flag for student/customer-facing views
+- last update timestamp and next-action timestamp
+
 ## Minimum user-facing behaviors
 
 - create a schedule entry
 - view upcoming scheduled entries
 - edit the basic fields of an entry
 - cancel an entry without deleting historical intent
+- create a cohort/session/assignment/review deadline
+- view an internal next-action list
+- view overdue submissions, reviews, and follow-ups
+- record a student/customer request
+- record a submission received state and feedback returned state
+- expose a minimal external status page or export-ready view for a student or
+  customer
 
 ## Explicitly deferred from this slice
 
 - recurring execution logic beyond documenting the future contract
-- reminder delivery systems
-- attendee and invitation workflows
+- automated reminder delivery systems
+- full attendee and invitation workflows
 - external calendar synchronization
-- deep integrations with SYNAPSIS, SYMBIOSIS, ANVIL, NEXUS, or other suite
+- payment processing
+- full curriculum authoring
+- full CRM/helpdesk behavior outside schedule-bound requests
+- deep integrations with SYMBIOSIS, FURYOKU, ANVIL, NEXUS, LIBRARY, or other suite
   surfaces
 
 ## Why this is the right first slice
 
-This slice is large enough to prove that EPOCH can own scheduling data and user
-flows, but small enough to avoid coupling v1 delivery to unresolved suite-wide
-dependencies.
+This slice is large enough to prove that EPOCH can own scheduling data,
+education/service operating flow, and user-visible status, but small enough to
+avoid coupling v1 delivery to unresolved suite-wide dependencies.
 
 ## Ready-for-implementation check
 
@@ -56,3 +81,6 @@ The execution issue for this slice should only move into implementation after:
 - the runtime and packaging stance is explicit
 - the minimum contract is not disputed
 - deferred integrations stay deferred
+- the commercial education lane is accepted as the first operating proof
+- EPOCH MONITOR parity is scoped as a follow-on slice rather than mixed into the
+  first scheduling/admin implementation

--- a/docs/v1-minimal-scheduling-surface.md
+++ b/docs/v1-minimal-scheduling-surface.md
@@ -10,6 +10,13 @@ proves product ownership before broader suite integrations are attempted.
 The first slice should support a user creating, viewing, and updating a simple
 scheduled item with explicit time boundaries and timezone-aware behavior.
 
+## Implementation stance for v1
+
+- native C owns the scheduling model and mutation logic
+- the Avalonia desktop shell consumes the native core through explicit interop
+- C# stays limited to host, UI, and interop glue unless a documented exception
+  is required
+
 ## Minimum contract
 
 - title
@@ -46,5 +53,6 @@ dependencies.
 The execution issue for this slice should only move into implementation after:
 
 - the product boundary is accepted
+- the runtime and packaging stance is explicit
 - the minimum contract is not disputed
 - deferred integrations stay deferred


### PR DESCRIPTION
## Summary
- expand the EPOCH planning docs from a stub into a clearer execution set
- add an explicit runtime and packaging stance for native C plus Avalonia hosting
- keep the first execution slice aligned to a native core with a thin managed shell

## Why
EPOCH needed the implementation default to be explicit before code work began. This PR now carries the product boundary, runtime stance, and first execution slice in one place so the repo, issues, and project board point at the same architecture direction.

## Supports
- #1
- #4
- #6

## Notes
This is still a planning/bootstrap PR, not an implementation PR.
