### PR TITLE
Add sandbox payment provider prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ KHYRON, SYMBIOSIS, and CITADEL suite.
 - `docs/provider-adapter-selection-readiness-contract.md`
 - `docs/sandbox-calendar-adapter-prototype-contract.md`
 - `docs/sandbox-notification-provider-prototype-contract.md`
+- `docs/sandbox-payment-provider-prototype-contract.md`
 - `docs/customer-account-history-contract.md`
 
 ## Current implementation artifacts
@@ -84,6 +85,12 @@ KHYRON, SYMBIOSIS, and CITADEL suite.
   but still do not send email, LINE, SMS, NEXUS, or webhook messages, configure
   OAuth, store secrets, write provider records, or create customer-visible
   sends.
+  Sandbox payment provider prototype records can generate local
+  provider-neutral payment payload previews from quote, opportunity, and
+  package readiness records, but still do not create checkout sessions, send
+  invoices, capture payments, issue refunds, configure OAuth, store secrets,
+  create webhooks, write provider records, or create customer-visible payment
+  requests.
   Durable customer account history records link customer status, submissions,
   cohorts, service records, receipts, and customer-safe updates while remaining
   local-only and controlled-customer.
@@ -96,10 +103,10 @@ KHYRON, SYMBIOSIS, and CITADEL suite.
   public/customer access gateway controls, and internal-only LIBRARY
   sync/recovery controls plus provider-neutral calendar and notification
   provider handoff controls, auth/session readiness controls, and local
-  marketing conversion KPI controls, provider adapter go/no-go controls, and a
+  marketing conversion KPI controls, provider adapter go/no-go controls,
   sandbox calendar adapter prototype console, sandbox notification provider
-  prototype console, plus customer account history cards for controlled
-  customer-safe status timelines.
+  prototype console, sandbox payment provider prototype console, plus customer
+  account history cards for controlled customer-safe status timelines.
 - `web/seed-data.js`: demo commercial workflow covering leads, tracks, cohorts,
   offer packages, curriculum frameworks, package gameplans, opportunities,
   update events, sessions, assignments, submissions, reviews, follow-ups,
@@ -112,8 +119,8 @@ KHYRON, SYMBIOSIS, and CITADEL suite.
   and under-19 guarded routes, plus provider adapter candidate records for
   calendar, notification, payment, auth/session, analytics, and persistence
   go/no-go readiness, a local calendar payload-preview prototype, and durable
-  customer account history records, plus a sandbox notification provider
-  message-preview prototype.
+  customer account history records, plus sandbox notification provider
+  message-preview and sandbox payment provider checkout-preview prototypes.
 - `tools/verify-commercial-slice.mjs`: repository verifier for the first
   commercial slice.
 

--- a/docs/first-commercial-slice-checklist.md
+++ b/docs/first-commercial-slice-checklist.md
@@ -40,6 +40,7 @@ service operations without waiting for every future CITADEL integration.
 - Marketing conversion KPI event linked to a campaign route.
 - Provider adapter candidate and go/no-go readiness record.
 - Sandbox notification provider prototype record.
+- Sandbox payment provider prototype record.
 - Durable customer account history record.
 
 ## Required operating states
@@ -115,6 +116,10 @@ service operations without waiting for every future CITADEL integration.
   previews from customer-safe update records while keeping live email, LINE,
   SMS, NEXUS, OAuth, secrets, webhooks, provider writes, and customer-visible
   sends disabled.
+- Sandbox payment provider prototypes prepare local payment payload previews
+  from quote, opportunity, and package readiness records while keeping live
+  checkout, invoice sending, capture, refunds, OAuth, secrets, webhooks,
+  provider writes, and customer-visible payment requests disabled.
 - Durable customer account history links status, submissions, cohorts, service
   records, receipts, and customer-safe updates while remaining local-only and
   controlled-customer.

--- a/docs/integration-priority-ranking.md
+++ b/docs/integration-priority-ranking.md
@@ -180,6 +180,20 @@ Current EPOCH-side sandbox notification provider prototype slice:
   email, LINE, SMS, NEXUS, OAuth clients, secrets, webhooks, provider writes,
   production behavior, or customer-visible notification events.
 
+Current EPOCH-side sandbox payment provider prototype slice:
+
+- `paymentProviderPrototypes` records local payment payload-preview prototypes
+  linked to payment provider adapter candidates and invoice/checkout handoff
+  readiness.
+- `summarizePaymentProviderPrototypeState` exposes payload-ready,
+  sandbox-only, local-only, no-live-payment, no-secrets,
+  no-customer-visible-payment, no-capture, legal/tax/privacy review, under-19
+  guard, and violation counts to EPOCH MONITOR.
+- `transitionPaymentProviderPrototypeRecords` creates internal monitor health
+  checks and `payment-provider-prototype` receipts without live checkout,
+  invoice sending, capture, refunds, OAuth clients, secrets, webhooks, provider
+  writes, production behavior, or customer-visible payment requests.
+
 Current EPOCH-side customer account history slice:
 
 - `customerAccountHistories` records controlled customer-safe timelines across

--- a/docs/monitor-parity-health-controls.md
+++ b/docs/monitor-parity-health-controls.md
@@ -22,6 +22,7 @@ EPOCH MONITOR must expose these local operator sections:
 - LIBRARY Sync
 - Calendar Providers
 - Notification Providers
+- Sandbox Payment Provider
 - Marketing Conversion KPIs
 - Provider Adapter Go/No-Go
 - Customer Account History
@@ -50,6 +51,9 @@ The current action classes are:
 - Calendar provider handoff and invitation-readiness review.
 - Notification provider handoff, template readiness, and consent-readiness
   review.
+- Sandbox payment provider prototype review for local payment payload previews
+  before live checkout, capture, refunds, invoice sending, credentials,
+  webhooks, provider writes, or customer-visible payment requests.
 - Marketing conversion KPI readiness for route-attributed, first-party,
   no-live-tracking campaign measurement.
 - Provider adapter go/no-go readiness for sandbox-only candidate selection
@@ -161,6 +165,14 @@ The repository verifier must cover:
   no-webhook/no-provider-write/no-customer-visible-send enforcement, internal
   `notification-provider-prototype` receipts, export/import preservation,
   monitor summary counts, and the `monitor-notification-prototype` section.
+- Sandbox payment provider prototype controls and verifier coverage for
+  `paymentProviderPrototypes`, local payment payload previews, payment provider
+  handoff and provider-adapter linkage, legal/tax/privacy review posture,
+  under-19 eligibility gating, no-live-payment/no-secrets/no-OAuth/no-webhook/
+  no-provider-write/no-checkout-session/no-payment-capture/no-refund/
+  no-invoice-send/no-customer-visible-payment enforcement, internal
+  `payment-provider-prototype` receipts, export/import preservation, monitor
+  summary counts, and the `monitor-payment-prototype` section.
 - Customer account history controls and verifier coverage for
   `customerAccountHistories`, controlled-customer status timelines,
   submission/cohort/service/receipt linkage, local-only enforcement, no live

--- a/docs/sandbox-payment-provider-prototype-contract.md
+++ b/docs/sandbox-payment-provider-prototype-contract.md
@@ -1,0 +1,106 @@
+# Sandbox Payment Provider Prototype Contract
+
+## Purpose
+
+EPOCH needs a payment-provider proof before any payment processor work, but the
+first slice must stay sandbox-only and local-first. The prototype proves that
+quotes, package prices, under-19 gates, and invoice/checkout readiness can be
+rendered into provider-neutral payment payload previews without creating live
+checkout sessions, sending invoices, capturing money, issuing refunds, storing
+credentials, configuring OAuth, creating webhooks, writing provider records, or
+showing customer-visible payment requests.
+
+## Ledger Records
+
+`paymentProviderPrototypes` records define the local payment adapter proof.
+
+Required fields:
+
+- `providerCandidateId` pointing at a payment `providerAdapterCandidates` row.
+- `sourceHandoffId` pointing at a `paymentProviderHandoffs` row.
+- `adapterFamily: "payment"`
+- `paymentProcessorSchema: "epoch.quote-payment"`
+- `payloadMode: "provider-neutral-payment-json-preview"`
+- `payloadPreview` with local quote, opportunity, or package payment payloads.
+- `blockers` naming the missing live-provider prerequisites.
+- `readinessChecks` proving legal, tax, privacy, under-19, and no-live-payment
+  posture.
+
+Every prototype must remain:
+
+- `sandboxOnly: true`
+- `localOnly: true`
+- `livePaymentEnabled: false`
+- `liveCheckoutEnabled: false`
+- `liveCaptureEnabled: false`
+- `liveRefundEnabled: false`
+- `invoiceSendEnabled: false`
+- `checkoutSessionCreated: false`
+- `paymentLinkCreated: false`
+- `capturesPayment: false`
+- `externalProviderWrite: false`
+- `productionEnabled: false`
+- `secretsPresent: false`
+- `credentialsStored: false`
+- `storesCredentials: false`
+- `oauthConfigured: false`
+- `webhookEnabled: false`
+- `customerVisible: false`
+- `legalReviewRequired: true`
+- `taxReviewRequired: true`
+- `privacyReviewRequired: true`
+- `under19Guarded: true`
+
+Every prototype must also preserve these readiness tokens:
+
+- `provider-candidate-required`
+- `payment-provider-handoff-required`
+- `quote-payment-schema-stable`
+- `legal-review-required`
+- `tax-review-required`
+- `privacy-boundary-required`
+- `under19-eligibility-gate`
+- `sandbox-only-before-go-live`
+- `operator-approval-required`
+- `no-live-payment`
+- `no-secrets`
+- `no-oauth-client`
+- `no-webhooks`
+- `no-provider-writes`
+- `no-checkout-session`
+- `no-payment-capture`
+- `no-refunds`
+- `no-invoice-send`
+- `no-customer-visible-payment-request`
+
+## Monitor Surface
+
+The prototype appears on `monitor-payment-prototype` as `Sandbox Payment
+Provider`. The monitor summary must count payload-ready prototypes, sandbox-only
+records, local-only records, no-live-payment posture, no-secrets posture,
+no-customer-visible-payment posture, no-capture posture, legal/tax/privacy
+review posture, under-19 guard posture, and violations.
+
+## Actions
+
+`transitionPaymentProviderPrototypeRecords` supports:
+
+- `generate-preview`
+- `approve-sandbox`
+- `mark-reviewed`
+- `defer`
+- `block`
+
+Each action writes an internal `payment-provider-prototype` receipt and a
+`payment-provider-sandbox-proof` monitor health check. None of the actions may
+create notification events, customer-visible payment requests, live checkout
+sessions, invoice sends, captures, refunds, OAuth clients, secrets, webhooks, or
+provider writes.
+
+## Future Go-Live Boundary
+
+A later live payment slice must be explicitly approved and must replace this
+contract with a narrower processor-specific contract covering legal/tax
+handling, privacy notices, under-19 guardian consent, refunds, webhooks,
+credential storage, idempotency, reconciliation, and customer-visible payment
+copy.

--- a/tools/verify-commercial-slice.mjs
+++ b/tools/verify-commercial-slice.mjs
@@ -43,6 +43,7 @@ const requiredCollections = [
   "providerAdapterCandidates",
   "calendarAdapterPrototypes",
   "notificationProviderPrototypes",
+  "paymentProviderPrototypes",
   "leads",
   "opportunities",
   "routePlacements",
@@ -108,6 +109,7 @@ if (!Array.isArray(data.notificationProviderHandoffs)) fail("seed data missing n
 if (!Array.isArray(data.paymentProviderHandoffs)) fail("seed data missing paymentProviderHandoffs collection");
 if (!Array.isArray(data.authSessionRoleHandoffs)) fail("seed data missing authSessionRoleHandoffs collection");
 if (!Array.isArray(data.calendarAdapterPrototypes)) fail("seed data missing calendarAdapterPrototypes collection");
+if (!Array.isArray(data.paymentProviderPrototypes)) fail("seed data missing paymentProviderPrototypes collection");
 if (!Array.isArray(data.customerAccountHistories)) fail("seed data missing customerAccountHistories collection");
 
 const header = read("../native/epoch_core.h");
@@ -222,7 +224,17 @@ for (const id of [
   "calendar-adapter-select",
   "calendar-adapter-action",
   "calendar-adapter-apply",
-  "calendar-adapter-confirmation"
+  "calendar-adapter-confirmation",
+  "notification-prototype-form",
+  "notification-prototype-select",
+  "notification-prototype-action",
+  "notification-prototype-apply",
+  "notification-prototype-confirmation",
+  "payment-prototype-form",
+  "payment-prototype-select",
+  "payment-prototype-action",
+  "payment-prototype-apply",
+  "payment-prototype-confirmation"
 ]) {
   if (!html.includes(`id="${id}"`)) fail(`web surface missing ${id}`);
 }
@@ -268,6 +280,9 @@ for (const field of ["handoffId", "action", "note"]) {
 for (const field of ["prototypeId", "action", "note"]) {
   if (!html.includes(`name="${field}"`)) fail(`sandbox notification provider form missing field ${field}`);
 }
+for (const field of ["prototypeId", "action", "note"]) {
+  if (!html.includes(`name="${field}"`)) fail(`sandbox payment provider form missing field ${field}`);
+}
 for (const field of ["handoffId", "action", "note"]) {
   if (!html.includes(`name="${field}"`)) fail(`payment provider form missing field ${field}`);
 }
@@ -277,7 +292,7 @@ for (const field of ["handoffId", "action", "note"]) {
 for (const field of ["assignmentId", "reviewDueAt", "submissionTitle", "submissionSummary"]) {
   if (!html.includes(`name="${field}"`)) fail(`submission form missing field ${field}`);
 }
-for (const phrase of ["data-monitor-target", "href=\"#monitor\"", "Direct route", "monitor-command-strip", "monitor-calendar", "monitor-handoffs", "monitor-suite", "monitor-library-sync", "monitor-calendar-provider", "monitor-notification-provider", "monitor-notification-prototype", "monitor-payment-provider", "monitor-auth-session", "monitor-persistence", "monitor-scope", "monitor-memory", "monitor-access"]) {
+for (const phrase of ["data-monitor-target", "href=\"#monitor\"", "Direct route", "monitor-command-strip", "monitor-calendar", "monitor-handoffs", "monitor-suite", "monitor-library-sync", "monitor-calendar-provider", "monitor-notification-provider", "monitor-notification-prototype", "monitor-payment-provider", "monitor-payment-prototype", "monitor-auth-session", "monitor-persistence", "monitor-scope", "monitor-memory", "monitor-access"]) {
   if (!html.includes(phrase)) fail(`monitor route surface missing phrase ${phrase}`);
 }
 for (const phrase of ["monitor-curriculum", "Package Gameplans", "Personalized Gameplan", "Curriculum Frameworks"]) {
@@ -297,6 +312,9 @@ for (const phrase of ["Notification Providers", "Notification Provider Handoffs"
 }
 for (const phrase of ["Payment Providers", "Payment Provider Handoffs", "Apply Payment Provider Action"]) {
   if (!html.includes(phrase)) fail(`payment provider HTML missing phrase ${phrase}`);
+}
+for (const phrase of ["Sandbox Payment Provider", "Apply Sandbox Payment Provider Action", "monitor-payment-prototype", "live checkout, invoice sending, capture, refunds, OAuth, secrets, webhooks, provider writes, and customer-visible payment requests remain disabled"]) {
+  if (!html.includes(phrase)) fail(`sandbox payment provider HTML missing phrase ${phrase}`);
 }
 for (const phrase of ["Auth Sessions", "Auth Session Role Handoffs", "Apply Auth Session Role Action"]) {
   if (!html.includes(phrase)) fail(`auth/session role HTML missing phrase ${phrase}`);
@@ -612,6 +630,8 @@ for (const phrase of [
   "marketing-conversion-console",
   "provider-adapter-console",
   "calendar-adapter-console",
+  "notification-prototype-console",
+  "payment-prototype-console",
   "monitor-action-button",
   "button-meta",
   "monitor-command-strip",
@@ -771,6 +791,30 @@ for (const prototype of data.notificationProviderPrototypes) {
   }
   if (!Array.isArray(prototype.payloadPreview) || !prototype.payloadPreview.length) fail(`notification provider prototype ${prototype.id} missing local payload preview`);
   if (!Array.isArray(prototype.blockers) || !prototype.blockers.length) fail(`notification provider prototype ${prototype.id} missing blockers`);
+}
+if (!Array.isArray(data.paymentProviderPrototypes) || data.paymentProviderPrototypes.length < 1) fail("seed data missing sandbox payment provider prototype records");
+if (!data.receipts.some((item) => item.kind === "payment-provider-prototype")) fail("seed data missing payment-provider-prototype receipt");
+if (!data.monitorHealthChecks.some((item) => item.target === "monitor-payment-prototype" && item.effect === "payment-provider-sandbox-proof")) fail("seed data missing sandbox payment provider monitor health check");
+for (const prototype of data.paymentProviderPrototypes) {
+  if (!data.providerAdapterCandidates.some((item) => item.id === prototype.providerCandidateId && item.providerFamily === "payment")) fail(`payment provider prototype ${prototype.id} does not link to a payment provider adapter candidate`);
+  if (!data.paymentProviderHandoffs.some((item) => item.id === prototype.sourceHandoffId)) fail(`payment provider prototype ${prototype.id} does not link to a payment provider handoff`);
+  if (prototype.adapterFamily !== "payment") fail(`payment provider prototype ${prototype.id} is not in the payment family`);
+  if (prototype.sandboxOnly !== true || prototype.localOnly !== true) fail(`payment provider prototype ${prototype.id} must remain sandbox/local only`);
+  if (prototype.livePaymentEnabled !== false || prototype.liveCheckoutEnabled !== false || prototype.liveCaptureEnabled !== false || prototype.liveRefundEnabled !== false || prototype.invoiceSendEnabled !== false || prototype.checkoutSessionCreated !== false || prototype.paymentLinkCreated !== false || prototype.capturesPayment !== false || prototype.externalProviderWrite !== false || prototype.productionEnabled !== false) {
+    fail(`payment provider prototype ${prototype.id} enabled live payment provider behavior`);
+  }
+  if (prototype.secretsPresent !== false || prototype.credentialsStored !== false || prototype.storesCredentials !== false || prototype.oauthConfigured !== false || prototype.webhookEnabled !== false) {
+    fail(`payment provider prototype ${prototype.id} enabled secrets, credentials, OAuth, or webhooks`);
+  }
+  if (prototype.customerVisible !== false || prototype.customerSafe !== false) fail(`payment provider prototype ${prototype.id} should remain internal-only`);
+  if (prototype.legalReviewRequired !== true || prototype.taxReviewRequired !== true || prototype.privacyReviewRequired !== true || prototype.under19Guarded !== true) {
+    fail(`payment provider prototype ${prototype.id} lost legal/tax/privacy or under-19 guard posture`);
+  }
+  for (const requiredCheck of ["provider-candidate-required", "payment-provider-handoff-required", "quote-payment-schema-stable", "legal-review-required", "tax-review-required", "privacy-boundary-required", "under19-eligibility-gate", "sandbox-only-before-go-live", "operator-approval-required", "no-live-payment", "no-secrets", "no-oauth-client", "no-webhooks", "no-provider-writes", "no-checkout-session", "no-payment-capture", "no-refunds", "no-invoice-send", "no-customer-visible-payment-request"]) {
+    if (!prototype.readinessChecks.includes(requiredCheck)) fail(`payment provider prototype ${prototype.id} missing ${requiredCheck}`);
+  }
+  if (!Array.isArray(prototype.payloadPreview) || !prototype.payloadPreview.length) fail(`payment provider prototype ${prototype.id} missing local payload preview`);
+  if (!Array.isArray(prototype.blockers) || !prototype.blockers.length) fail(`payment provider prototype ${prototype.id} missing blockers`);
 }
 if (!Array.isArray(data.customerAccountHistories) || data.customerAccountHistories.length < data.customers.length) fail("seed data missing durable customer account history records");
 if (!data.receipts.some((item) => item.kind === "customer-account-history" || item.id === "receipt-client-request-seed")) fail("seed data missing customer account history receipt evidence");
@@ -1344,6 +1388,76 @@ if (notificationPrototypeTransitionResult.records.prototype.liveSendEnabled || n
   fail("notification prototype transition enabled live provider or secret safeguards");
 }
 
+const paymentPrototypeSummary = recordTools.summarizePaymentProviderPrototypeState(data);
+if (paymentPrototypeSummary.prototypeCount !== data.paymentProviderPrototypes.length) fail("payment prototype summary total is wrong");
+if (paymentPrototypeSummary.payloadReady < 1) fail("payment prototype summary missing payload-ready prototype");
+if (paymentPrototypeSummary.sandboxOnly !== data.paymentProviderPrototypes.length) fail("payment prototype summary missing sandbox-only prototypes");
+if (paymentPrototypeSummary.localOnly !== data.paymentProviderPrototypes.length) fail("payment prototype summary missing local-only prototypes");
+if (paymentPrototypeSummary.noLivePayment !== data.paymentProviderPrototypes.length) fail("payment prototype summary no-live-payment count is wrong");
+if (paymentPrototypeSummary.noSecrets !== data.paymentProviderPrototypes.length) fail("payment prototype summary no-secrets count is wrong");
+if (paymentPrototypeSummary.noCustomerVisiblePayment !== data.paymentProviderPrototypes.length) fail("payment prototype summary no-customer-visible-payment count is wrong");
+if (paymentPrototypeSummary.noPaymentCapture !== data.paymentProviderPrototypes.length) fail("payment prototype summary no-payment-capture count is wrong");
+if (paymentPrototypeSummary.legalTaxPrivacyReady !== data.paymentProviderPrototypes.length) fail("payment prototype summary legal/tax/privacy count is wrong");
+if (paymentPrototypeSummary.under19Guarded !== data.paymentProviderPrototypes.length) fail("payment prototype summary under-19 guard count is wrong");
+if (paymentPrototypeSummary.violations.length !== 0) fail("payment prototype summary should not report seed violations");
+
+const malformedPaymentPrototypeData = recordTools.cloneData(data);
+malformedPaymentPrototypeData.paymentProviderPrototypes[0] = {
+  ...malformedPaymentPrototypeData.paymentProviderPrototypes[0],
+  livePaymentEnabled: true,
+  liveCheckoutEnabled: true,
+  liveCaptureEnabled: true,
+  liveRefundEnabled: true,
+  invoiceSendEnabled: true,
+  checkoutSessionCreated: true,
+  paymentLinkCreated: true,
+  capturesPayment: true,
+  externalProviderWrite: true,
+  secretsPresent: true,
+  credentialsStored: true,
+  storesCredentials: true,
+  oauthConfigured: true,
+  webhookEnabled: true,
+  customerVisible: true,
+  legalReviewRequired: false,
+  taxReviewRequired: false,
+  privacyReviewRequired: false,
+  under19Guarded: false,
+  readinessChecks: [],
+  payloadPreview: []
+};
+const malformedPaymentPrototypeSummary = recordTools.summarizePaymentProviderPrototypeState(malformedPaymentPrototypeData);
+if (malformedPaymentPrototypeSummary.status !== "blocked" || malformedPaymentPrototypeSummary.violations.length < 4) fail("payment prototype summary did not flag live provider/secret/legal violations");
+
+const paymentPrototypeCreateResult = recordTools.createPaymentProviderPrototypeRecords(data, {
+  providerCandidateId: "provider-adapter-payment-checkout",
+  sourceHandoffId: "payment-provider-checkout-readiness",
+  note: "Verifier created a local payment payload preview without live provider behavior."
+}, { now: "2026-06-01T12:17:00+09:00" });
+if (paymentPrototypeCreateResult.data.paymentProviderPrototypes.length !== data.paymentProviderPrototypes.length + 1) fail("payment prototype create did not add a prototype");
+if (paymentPrototypeCreateResult.records.prototype.livePaymentEnabled || paymentPrototypeCreateResult.records.prototype.liveCheckoutEnabled || paymentPrototypeCreateResult.records.prototype.liveCaptureEnabled || paymentPrototypeCreateResult.records.prototype.liveRefundEnabled || paymentPrototypeCreateResult.records.prototype.invoiceSendEnabled || paymentPrototypeCreateResult.records.prototype.checkoutSessionCreated || paymentPrototypeCreateResult.records.prototype.paymentLinkCreated || paymentPrototypeCreateResult.records.prototype.capturesPayment || paymentPrototypeCreateResult.records.prototype.externalProviderWrite || paymentPrototypeCreateResult.records.prototype.productionEnabled || paymentPrototypeCreateResult.records.prototype.secretsPresent || paymentPrototypeCreateResult.records.prototype.credentialsStored || paymentPrototypeCreateResult.records.prototype.storesCredentials || paymentPrototypeCreateResult.records.prototype.oauthConfigured || paymentPrototypeCreateResult.records.prototype.webhookEnabled) {
+  fail("payment prototype create enabled live provider behavior, secrets, OAuth, or webhooks");
+}
+if (!paymentPrototypeCreateResult.records.prototype.payloadPreview.length) fail("payment prototype create did not generate a payload preview");
+if (paymentPrototypeCreateResult.records.receipt.kind !== "payment-provider-prototype") fail("payment prototype create missing receipt kind");
+if (paymentPrototypeCreateResult.records.healthCheck.target !== "monitor-payment-prototype") fail("payment prototype create missing monitor target");
+if (paymentPrototypeCreateResult.data.notificationEvents.length !== data.notificationEvents.length) fail("payment prototype create created a customer-visible notification event");
+
+const paymentPrototypeTransitionResult = recordTools.transitionPaymentProviderPrototypeRecords(data, {
+  prototypeId: "payment-provider-sandbox-checkout-preview",
+  action: "approve-sandbox",
+  note: "Verifier approved sandbox payment payload proof without live checkout, invoice sending, capture, refunds, OAuth, secrets, webhooks, provider writes, or customer-visible payment requests."
+}, { now: "2026-06-01T12:18:00+09:00" });
+if (paymentPrototypeTransitionResult.records.prototype.status !== "approved") fail("payment prototype transition did not approve sandbox status");
+if (paymentPrototypeTransitionResult.records.prototype.prototypeStatus !== "sandbox-approved") fail("payment prototype transition did not set sandbox-approved state");
+if (paymentPrototypeTransitionResult.records.receipt.kind !== "payment-provider-prototype") fail("payment prototype transition missing receipt kind");
+if (paymentPrototypeTransitionResult.records.healthCheck.effect !== "payment-provider-sandbox-proof") fail("payment prototype transition missing monitor effect");
+if (paymentPrototypeTransitionResult.records.healthCheck.customerVisible !== false) fail("payment prototype health check must remain internal");
+if (paymentPrototypeTransitionResult.data.notificationEvents.length !== data.notificationEvents.length) fail("payment prototype transition created a customer-visible notification event");
+if (paymentPrototypeTransitionResult.records.prototype.livePaymentEnabled || paymentPrototypeTransitionResult.records.prototype.liveCheckoutEnabled || paymentPrototypeTransitionResult.records.prototype.liveCaptureEnabled || paymentPrototypeTransitionResult.records.prototype.liveRefundEnabled || paymentPrototypeTransitionResult.records.prototype.invoiceSendEnabled || paymentPrototypeTransitionResult.records.prototype.checkoutSessionCreated || paymentPrototypeTransitionResult.records.prototype.paymentLinkCreated || paymentPrototypeTransitionResult.records.prototype.capturesPayment || paymentPrototypeTransitionResult.records.prototype.externalProviderWrite || paymentPrototypeTransitionResult.records.prototype.productionEnabled || paymentPrototypeTransitionResult.records.prototype.secretsPresent || paymentPrototypeTransitionResult.records.prototype.credentialsStored || paymentPrototypeTransitionResult.records.prototype.storesCredentials || paymentPrototypeTransitionResult.records.prototype.oauthConfigured || paymentPrototypeTransitionResult.records.prototype.webhookEnabled || paymentPrototypeTransitionResult.records.prototype.customerVisible) {
+  fail("payment prototype transition enabled live provider or secret safeguards");
+}
+
 const accountHistorySummary = recordTools.summarizeCustomerAccountHistoryState(data);
 if (accountHistorySummary.historyCount !== data.customers.length) fail("account history summary should cover every customer");
 if (accountHistorySummary.timelineEvents < data.customerAccountHistories.length) fail("account history summary missing timeline events");
@@ -1610,6 +1724,29 @@ for (const phrase of [
   "no-customer-visible-send"
 ]) {
   if (!notificationPrototypeContract.includes(phrase)) fail(`sandbox notification provider contract missing phrase: ${phrase}`);
+}
+
+const paymentPrototypeContract = read("../docs/sandbox-payment-provider-prototype-contract.md");
+for (const phrase of [
+  "Sandbox Payment Provider Prototype Contract",
+  "paymentProviderPrototypes",
+  "monitor-payment-prototype",
+  "transitionPaymentProviderPrototypeRecords",
+  "payment-provider-prototype",
+  "sandboxOnly: true",
+  "localOnly: true",
+  "livePaymentEnabled: false",
+  "liveCheckoutEnabled: false",
+  "capturesPayment: false",
+  "oauthConfigured: false",
+  "legalReviewRequired: true",
+  "taxReviewRequired: true",
+  "under19Guarded: true",
+  "no-live-payment",
+  "no-payment-capture",
+  "no-customer-visible-payment-request"
+]) {
+  if (!paymentPrototypeContract.includes(phrase)) fail(`sandbox payment provider contract missing phrase: ${phrase}`);
 }
 
 const accountHistoryContract = read("../docs/customer-account-history-contract.md");
@@ -2402,6 +2539,7 @@ if (!monitorReport.librarySync) fail("monitor report missing LIBRARY sync state"
 if (!monitorReport.calendarProvider) fail("monitor report missing calendar provider state");
 if (!monitorReport.notificationProvider) fail("monitor report missing notification provider state");
 if (!monitorReport.paymentProvider) fail("monitor report missing payment provider state");
+if (!monitorReport.paymentPrototype) fail("monitor report missing sandbox payment provider state");
 if (!monitorReport.authSession) fail("monitor report missing auth/session role state");
 if (!Array.isArray(monitorReport.monitorHealthChecks)) fail("monitor report missing monitor health checks");
 if (!Array.isArray(monitorReport.operatorActions)) fail("monitor report missing operator actions");
@@ -2477,6 +2615,17 @@ if (monitorReport.summary.paymentInvoiceReady < 2) fail("monitor summary missing
 if (monitorReport.summary.paymentCheckoutReady < 1) fail("monitor summary missing payment checkout readiness handoff count");
 if (monitorReport.summary.paymentEligibilityReady < 2) fail("monitor summary missing payment eligibility readiness handoff count");
 if (monitorReport.summary.paymentProviderViolations !== 0) fail("monitor summary should not report payment provider violations for the seed slice");
+if (monitorReport.summary.paymentProviderPrototypes !== data.paymentProviderPrototypes.length) fail("monitor summary payment provider prototype count is wrong");
+if (monitorReport.summary.paymentPrototypePayloadReady < 1) fail("monitor summary missing payload-ready payment provider prototype");
+if (monitorReport.summary.paymentPrototypeSandboxOnly !== data.paymentProviderPrototypes.length) fail("monitor summary missing sandbox-only payment provider prototypes");
+if (monitorReport.summary.paymentPrototypeLocalOnly !== data.paymentProviderPrototypes.length) fail("monitor summary missing local-only payment provider prototypes");
+if (monitorReport.summary.paymentPrototypeNoLivePayment !== data.paymentProviderPrototypes.length) fail("monitor summary missing no-live-payment provider prototypes");
+if (monitorReport.summary.paymentPrototypeNoSecrets !== data.paymentProviderPrototypes.length) fail("monitor summary missing no-secrets payment provider prototypes");
+if (monitorReport.summary.paymentPrototypeNoCustomerVisiblePayment !== data.paymentProviderPrototypes.length) fail("monitor summary missing no-customer-visible-payment provider prototypes");
+if (monitorReport.summary.paymentPrototypeNoPaymentCapture !== data.paymentProviderPrototypes.length) fail("monitor summary missing no-payment-capture provider prototypes");
+if (monitorReport.summary.paymentPrototypeLegalTaxPrivacyReady !== data.paymentProviderPrototypes.length) fail("monitor summary missing legal/tax/privacy payment provider prototypes");
+if (monitorReport.summary.paymentPrototypeUnder19Guarded !== data.paymentProviderPrototypes.length) fail("monitor summary missing under-19 guarded payment provider prototypes");
+if (monitorReport.summary.paymentPrototypeViolations !== 0) fail("monitor summary should not report payment prototype violations for the seed slice");
 if (monitorReport.summary.authSessionRoleHandoffs < 4) fail("monitor summary missing auth/session role handoff count");
 if (monitorReport.summary.authPublicReady < 1) fail("monitor summary missing public auth readiness count");
 if (monitorReport.summary.authCustomerReady < 1) fail("monitor summary missing customer auth readiness count");
@@ -2490,6 +2639,7 @@ if (!monitorReport.timeline.some((item) => item.kind === "marketing conversion")
 if (!monitorReport.timeline.some((item) => item.kind === "provider adapter")) fail("monitor timeline missing provider adapter candidates");
 if (!monitorReport.timeline.some((item) => item.kind === "calendar adapter")) fail("monitor timeline missing sandbox calendar adapter prototypes");
 if (!monitorReport.timeline.some((item) => item.kind === "notification prototype")) fail("monitor timeline missing sandbox notification provider prototypes");
+if (!monitorReport.timeline.some((item) => item.kind === "payment prototype")) fail("monitor timeline missing sandbox payment provider prototypes");
 if (!monitorReport.timeline.some((item) => item.kind === "access gateway")) fail("monitor timeline missing access gateways");
 if (!monitorReport.timeline.some((item) => item.kind === "library sync")) fail("monitor timeline missing LIBRARY sync handoffs");
 if (!monitorReport.timeline.some((item) => item.kind === "calendar provider")) fail("monitor timeline missing calendar provider handoffs");
@@ -2575,6 +2725,7 @@ if (exportedLedger.counts.marketingConversionEvents !== returnResult.data.market
 if (exportedLedger.counts.providerAdapterCandidates !== returnResult.data.providerAdapterCandidates.length) fail("ledger export provider adapter count is wrong");
 if (exportedLedger.counts.calendarAdapterPrototypes !== returnResult.data.calendarAdapterPrototypes.length) fail("ledger export calendar adapter prototype count is wrong");
 if (exportedLedger.counts.notificationProviderPrototypes !== returnResult.data.notificationProviderPrototypes.length) fail("ledger export notification provider prototype count is wrong");
+if (exportedLedger.counts.paymentProviderPrototypes !== returnResult.data.paymentProviderPrototypes.length) fail("ledger export payment provider prototype count is wrong");
 if (exportedLedger.counts.customerAccountHistories !== exportedLedger.data.customerAccountHistories.length) fail("ledger export account history count is wrong");
 if (!exportedLedger.monitor || exportedLedger.monitor.timeline < 1) fail("ledger export missing monitor summary");
 if (exportedLedger.monitor.persistenceRevision !== exportedLedger.persistence.revision) fail("ledger monitor summary missing persistence revision");
@@ -2590,6 +2741,7 @@ if (!exportedLedger.marketingConversion || exportedLedger.marketingConversion.ev
 if (!exportedLedger.providerAdapters || exportedLedger.providerAdapters.candidateCount !== exportedLedger.data.providerAdapterCandidates.length) fail("ledger export missing provider adapter summary");
 if (!exportedLedger.calendarAdapter || exportedLedger.calendarAdapter.prototypeCount !== exportedLedger.data.calendarAdapterPrototypes.length) fail("ledger export missing calendar adapter summary");
 if (!exportedLedger.notificationPrototype || exportedLedger.notificationPrototype.prototypeCount !== exportedLedger.data.notificationProviderPrototypes.length) fail("ledger export missing notification prototype summary");
+if (!exportedLedger.paymentPrototype || exportedLedger.paymentPrototype.prototypeCount !== exportedLedger.data.paymentProviderPrototypes.length) fail("ledger export missing payment prototype summary");
 if (!exportedLedger.accountHistory || exportedLedger.accountHistory.historyCount !== exportedLedger.data.customers.length) fail("ledger export missing account history summary");
 if (exportedLedger.counts.routePlacements !== returnResult.data.routePlacements.length) fail("ledger export route placement count is wrong");
 if (exportedLedger.counts.curriculumFrameworks !== returnResult.data.curriculumFrameworks.length) fail("ledger export curriculum framework count is wrong");
@@ -2621,6 +2773,11 @@ if (exportedLedger.monitor.calendarAdapterNoInvitationSend !== returnResult.data
 if (exportedLedger.monitor.notificationProviderPrototypes !== returnResult.data.notificationProviderPrototypes.length) fail("ledger monitor summary missing notification provider prototypes");
 if (exportedLedger.monitor.notificationPrototypeNoLiveSend !== returnResult.data.notificationProviderPrototypes.length) fail("ledger monitor summary missing notification prototype no-live-send posture");
 if (exportedLedger.monitor.notificationPrototypeNoCustomerVisibleSend !== returnResult.data.notificationProviderPrototypes.length) fail("ledger monitor summary missing notification prototype no-customer-visible-send posture");
+if (exportedLedger.monitor.paymentProviderPrototypes !== returnResult.data.paymentProviderPrototypes.length) fail("ledger monitor summary missing payment provider prototypes");
+if (exportedLedger.monitor.paymentPrototypeNoLivePayment !== returnResult.data.paymentProviderPrototypes.length) fail("ledger monitor summary missing payment prototype no-live-payment posture");
+if (exportedLedger.monitor.paymentPrototypeNoCustomerVisiblePayment !== returnResult.data.paymentProviderPrototypes.length) fail("ledger monitor summary missing payment prototype no-customer-visible-payment posture");
+if (exportedLedger.monitor.paymentPrototypeNoPaymentCapture !== returnResult.data.paymentProviderPrototypes.length) fail("ledger monitor summary missing payment prototype no-capture posture");
+if (exportedLedger.monitor.paymentPrototypeUnder19Guarded !== returnResult.data.paymentProviderPrototypes.length) fail("ledger monitor summary missing payment prototype under-19 guard posture");
 if (exportedLedger.monitor.accountHistories !== exportedLedger.data.customers.length) fail("ledger monitor summary missing account histories");
 if (exportedLedger.monitor.accountHistoryLocalOnly !== exportedLedger.data.customers.length) fail("ledger monitor summary missing account history local-only posture");
 if (exportedLedger.monitor.accountHistoryViolations !== 0) fail("ledger monitor summary should not report account history violations");
@@ -2691,6 +2848,15 @@ if (notificationPrototypeLedger.notificationPrototype.noLiveSend !== notificatio
 if (notificationPrototypeLedger.notificationPrototype.noCustomerVisibleSend !== notificationPrototypeTransitionResult.data.notificationProviderPrototypes.length) fail("ledger notification prototype summary lost no-customer-visible-send posture");
 if (notificationPrototypeLedger.monitor.notificationPrototypeViolations !== 0) fail("ledger monitor summary should not report notification prototype violations after transition");
 
+const paymentPrototypeLedger = recordTools.createOperatingLedger(paymentPrototypeTransitionResult.data, { now: "2026-06-01T04:43:59.500Z" });
+if (paymentPrototypeLedger.counts.paymentProviderPrototypes !== paymentPrototypeTransitionResult.data.paymentProviderPrototypes.length) fail("ledger export payment prototype transition count is wrong");
+if (paymentPrototypeLedger.paymentPrototype.payloadReady < 1) fail("ledger export missing payment prototype payload readiness after transition");
+if (paymentPrototypeLedger.paymentPrototype.noLivePayment !== paymentPrototypeTransitionResult.data.paymentProviderPrototypes.length) fail("ledger payment prototype summary lost no-live-payment posture");
+if (paymentPrototypeLedger.paymentPrototype.noCustomerVisiblePayment !== paymentPrototypeTransitionResult.data.paymentProviderPrototypes.length) fail("ledger payment prototype summary lost no-customer-visible-payment posture");
+if (paymentPrototypeLedger.paymentPrototype.noPaymentCapture !== paymentPrototypeTransitionResult.data.paymentProviderPrototypes.length) fail("ledger payment prototype summary lost no-capture posture");
+if (paymentPrototypeLedger.paymentPrototype.under19Guarded !== paymentPrototypeTransitionResult.data.paymentProviderPrototypes.length) fail("ledger payment prototype summary lost under-19 guard posture");
+if (paymentPrototypeLedger.monitor.paymentPrototypeViolations !== 0) fail("ledger monitor summary should not report payment prototype violations after transition");
+
 const accountHistoryLedger = recordTools.createOperatingLedger(accountHistoryRefreshResult.data, { now: "2026-06-01T04:43:59.500Z" });
 if (accountHistoryLedger.counts.customerAccountHistories !== accountHistoryLedger.data.customers.length) fail("ledger export account history refresh count is wrong");
 if (accountHistoryLedger.accountHistory.historyCount !== accountHistoryLedger.data.customers.length) fail("ledger export missing refreshed account history summary");
@@ -2722,6 +2888,7 @@ if (importedLedger.data.marketingConversionEvents.length !== returnResult.data.m
 if (importedLedger.data.providerAdapterCandidates.length !== returnResult.data.providerAdapterCandidates.length) fail("ledger import did not preserve provider adapter candidates");
 if (importedLedger.data.calendarAdapterPrototypes.length !== returnResult.data.calendarAdapterPrototypes.length) fail("ledger import did not preserve calendar adapter prototypes");
 if (importedLedger.data.notificationProviderPrototypes.length !== returnResult.data.notificationProviderPrototypes.length) fail("ledger import did not preserve notification provider prototypes");
+if (importedLedger.data.paymentProviderPrototypes.length !== returnResult.data.paymentProviderPrototypes.length) fail("ledger import did not preserve payment provider prototypes");
 if (importedLedger.data.customerAccountHistories.length !== exportedLedger.data.customerAccountHistories.length) fail("ledger import did not preserve account histories");
 if (importedLedger.data.campaignRoutes.length !== returnResult.data.campaignRoutes.length) fail("ledger import did not preserve campaign routes");
 if (importedLedger.data.customers[0].externalStatus !== returnResult.data.customers[0].externalStatus) fail("ledger import did not preserve external status");
@@ -2803,6 +2970,13 @@ if (importedNotificationPrototypeLedger.data.notificationProviderPrototypes.leng
 if (!importedNotificationPrototypeLedger.data.notificationProviderPrototypes.some((item) => item.prototypeStatus === "sandbox-approved")) fail("ledger import did not preserve notification provider prototype sandbox approval");
 if (!importedNotificationPrototypeLedger.data.notificationProviderPrototypes.every((item) => item.liveSendEnabled === false && item.liveEmailSend === false && item.liveLineSend === false && item.liveSmsSend === false && item.liveNexusSend === false && item.externalProviderWrite === false && item.productionEnabled === false && item.secretsPresent === false && item.credentialsStored === false && item.storesCredentials === false && item.oauthConfigured === false && item.webhookEnabled === false && item.customerVisible === false)) {
   fail("ledger import changed notification prototype no-live-send safeguards");
+}
+
+const importedPaymentPrototypeLedger = recordTools.importOperatingLedger(data, JSON.stringify(paymentPrototypeLedger));
+if (importedPaymentPrototypeLedger.data.paymentProviderPrototypes.length !== paymentPrototypeTransitionResult.data.paymentProviderPrototypes.length) fail("ledger import did not preserve payment provider prototypes after transition");
+if (!importedPaymentPrototypeLedger.data.paymentProviderPrototypes.some((item) => item.prototypeStatus === "sandbox-approved")) fail("ledger import did not preserve payment provider prototype sandbox approval");
+if (!importedPaymentPrototypeLedger.data.paymentProviderPrototypes.every((item) => item.livePaymentEnabled === false && item.liveCheckoutEnabled === false && item.liveCaptureEnabled === false && item.liveRefundEnabled === false && item.invoiceSendEnabled === false && item.checkoutSessionCreated === false && item.paymentLinkCreated === false && item.capturesPayment === false && item.externalProviderWrite === false && item.productionEnabled === false && item.secretsPresent === false && item.credentialsStored === false && item.storesCredentials === false && item.oauthConfigured === false && item.webhookEnabled === false && item.customerVisible === false)) {
+  fail("ledger import changed payment prototype no-live-payment safeguards");
 }
 
 const importedAccountHistoryLedger = recordTools.importOperatingLedger(data, JSON.stringify(accountHistoryLedger));

--- a/web/app.js
+++ b/web/app.js
@@ -67,7 +67,7 @@ function resetData() {
 
 function storageStatusText() {
   const persistence = recordTools.summarizePersistenceState(data);
-  return `Ledger v${recordTools.ledgerVersion} | ${data.customers.length} customers | ${(data.customerAccountHistories || []).length} account histories | ${data.engagements.length} engagements | ${data.campaignRoutes.length} campaigns | ${(data.marketingConversionEvents || []).length} conversion KPIs | ${(data.providerAdapterCandidates || []).length} provider adapters | ${(data.calendarAdapterPrototypes || []).length} calendar prototypes | ${(data.notificationProviderPrototypes || []).length} notification prototypes | ${(data.librarySyncHandoffs || []).length} LIBRARY handoffs | ${(data.calendarProviderHandoffs || []).length} calendar handoffs | ${(data.notificationProviderHandoffs || []).length} notification provider handoffs | ${(data.paymentProviderHandoffs || []).length} payment provider handoffs | ${(data.authSessionRoleHandoffs || []).length} auth/session handoffs | ${data.notificationEvents.length} updates | ${data.receipts.length} receipts | r${persistence.revision} ${persistence.adapterState} | ${persistence.ledgerId}`;
+  return `Ledger v${recordTools.ledgerVersion} | ${data.customers.length} customers | ${(data.customerAccountHistories || []).length} account histories | ${data.engagements.length} engagements | ${data.campaignRoutes.length} campaigns | ${(data.marketingConversionEvents || []).length} conversion KPIs | ${(data.providerAdapterCandidates || []).length} provider adapters | ${(data.calendarAdapterPrototypes || []).length} calendar prototypes | ${(data.notificationProviderPrototypes || []).length} notification prototypes | ${(data.paymentProviderPrototypes || []).length} payment prototypes | ${(data.librarySyncHandoffs || []).length} LIBRARY handoffs | ${(data.calendarProviderHandoffs || []).length} calendar handoffs | ${(data.notificationProviderHandoffs || []).length} notification provider handoffs | ${(data.paymentProviderHandoffs || []).length} payment provider handoffs | ${(data.authSessionRoleHandoffs || []).length} auth/session handoffs | ${data.notificationEvents.length} updates | ${data.receipts.length} receipts | r${persistence.revision} ${persistence.adapterState} | ${persistence.ledgerId}`;
 }
 
 function formatTime(value) {
@@ -580,6 +580,7 @@ function renderMonitor(items) {
   const notificationPrototype = report.notificationPrototype || recordTools.summarizeNotificationProviderPrototypeState(data);
   const quotes = report.quotes || recordTools.summarizeQuoteState(data);
   const paymentProvider = report.paymentProvider || recordTools.summarizePaymentProviderState(data, { quotes });
+  const paymentPrototype = report.paymentPrototype || recordTools.summarizePaymentProviderPrototypeState(data);
   const authSession = report.authSession || recordTools.summarizeAuthSessionRoleState(data);
   const accountHistory = report.accountHistory || recordTools.summarizeCustomerAccountHistoryState(data);
   const scheduleControls = report.scheduleControls || recordTools.summarizeScheduleControlState(data);
@@ -596,7 +597,7 @@ function renderMonitor(items) {
   const persistence = report.persistence || recordTools.summarizePersistenceState(data, { now: `${today}T12:00:00+09:00` });
   const librarySync = report.librarySync || recordTools.summarizeLibrarySyncState(data, { now: `${today}T12:00:00+09:00`, persistence });
   lastMonitorReport = report;
-  byId("monitor-route-status").textContent = `${routeForView("monitor")} | ${report.summary.queue} queued | ${report.summary.risks} risks | ${accountHistory.historyCount} account histories | ${routePlacement.summary.routeCount} SYNAPSE routes | ${accessGateways.gatewayCount} access gates | ${librarySync.handoffCount} LIBRARY handoffs | ${calendarProvider.handoffCount} calendar handoffs | ${calendarAdapter.payloadReady} calendar prototypes ready | ${notificationPrototype.payloadReady} notification prototypes ready | ${notificationProvider.handoffCount} notification provider handoffs | ${paymentProvider.handoffCount} payment provider handoffs | ${authSession.handoffCount} auth/session handoffs | ${marketing.ready} campaign routes ready | ${marketingConversion.readyEvents} conversion KPIs ready | ${providerAdapters.readyCandidates} provider adapters ready | ${persistence.adapterState}`;
+  byId("monitor-route-status").textContent = `${routeForView("monitor")} | ${report.summary.queue} queued | ${report.summary.risks} risks | ${accountHistory.historyCount} account histories | ${routePlacement.summary.routeCount} SYNAPSE routes | ${accessGateways.gatewayCount} access gates | ${librarySync.handoffCount} LIBRARY handoffs | ${calendarProvider.handoffCount} calendar handoffs | ${calendarAdapter.payloadReady} calendar prototypes ready | ${notificationPrototype.payloadReady} notification prototypes ready | ${paymentPrototype.payloadReady} payment prototypes ready | ${notificationProvider.handoffCount} notification provider handoffs | ${paymentProvider.handoffCount} payment provider handoffs | ${authSession.handoffCount} auth/session handoffs | ${marketing.ready} campaign routes ready | ${marketingConversion.readyEvents} conversion KPIs ready | ${providerAdapters.readyCandidates} provider adapters ready | ${persistence.adapterState}`;
   renderMonitorActionConsole(report);
 
   const summaryCards = [
@@ -613,6 +614,7 @@ function renderMonitor(items) {
     record("Notification Providers", `${notificationProvider.providerReady} provider handoffs, ${notificationProvider.templateReady} template-ready, ${notificationProvider.consentReady} consent-ready, ${notificationProvider.noLiveSend} no-live-send.`, [toneChip(notificationProvider.status, notificationProvider.status === "ready" ? "complete" : "blocked"), chip(`${notificationProvider.handoffCount} handoffs`)]),
     record("Sandbox Notification Prototype", `${notificationPrototype.payloadReady} of ${notificationPrototype.prototypeCount} prototypes payload-ready; ${notificationPrototype.noLiveSend} no-live-send, ${notificationPrototype.noSecrets} no-secrets, ${notificationPrototype.noCustomerVisibleSend} no-customer-visible-send.`, [toneChip(notificationPrototype.status, notificationPrototype.status === "ready" ? "complete" : "blocked"), chip(`${notificationPrototype.payloadEntries} payload items`)]),
     record("Payment Providers", `${paymentProvider.providerReady} provider handoffs, ${paymentProvider.invoiceReady} invoice-ready, ${paymentProvider.checkoutReady} checkout-ready, ${paymentProvider.noLivePayment} no-live-payment.`, [toneChip(paymentProvider.status, paymentProvider.status === "ready" ? "complete" : "blocked"), chip(`${paymentProvider.handoffCount} handoffs`)]),
+    record("Sandbox Payment Prototype", `${paymentPrototype.payloadReady} of ${paymentPrototype.prototypeCount} prototypes payload-ready; ${paymentPrototype.noLivePayment} no-live-payment, ${paymentPrototype.noSecrets} no-secrets, ${paymentPrototype.noPaymentCapture} no-capture, ${paymentPrototype.under19Guarded} under-19 guarded.`, [toneChip(paymentPrototype.status, paymentPrototype.status === "ready" ? "complete" : "blocked"), chip(`${paymentPrototype.payloadEntries} payload items`)]),
     record("Auth / Session Roles", `${authSession.publicReady} public, ${authSession.customerReady} customer, ${authSession.internalDenied} internal denied, ${authSession.noLiveAuth} no-live-auth.`, [toneChip(authSession.status, authSession.status === "ready" ? "complete" : "blocked"), chip(`${authSession.handoffCount} handoffs`)]),
     record("Operator Actions", `${report.operatorActions.length} local action${report.operatorActions.length === 1 ? "" : "s"} are queued in the monitor controls.`, [toneChip(`${report.operatorActions.length} queued`, report.operatorActions.length ? "overdue" : "complete")]),
     record("External Visibility", `${visibleCount} student/customer-visible records are available.`, [chip(`${visibleCount} visible`)]),
@@ -882,6 +884,17 @@ function renderMonitor(items) {
     ]
   ));
 
+  const paymentPrototypeCards = paymentPrototype.prototypes.map((prototype) => record(
+    prototype.title,
+    `${prototype.targetProvider} | ${prototype.adapterMode} | ${prototype.prototypeStatus} | ${prototype.payloadEntryCount} local preview items | ${prototype.notes}`,
+    [
+      statusChip(prototype.status),
+      chip(prototype.payloadMode),
+      chip(prototype.sandboxOnly && prototype.localOnly ? "sandbox-local" : "boundary-missing"),
+      toneChip(`${prototype.violations.length} violations`, prototype.violations.length ? "blocked" : "complete")
+    ]
+  ));
+
   const accountHistoryCards = accountHistory.histories.map((history) => {
     const eventPreview = (history.statusTimeline || [])
       .slice(0, 3)
@@ -962,6 +975,7 @@ function renderMonitor(items) {
     monitorSection("Provider Adapter Go/No-Go", providerAdapterCards.length ? providerAdapterCards : [record("Provider Adapter Go/No-Go", "No provider adapter candidate records have been created yet.", [chip("empty")])], "monitor-provider-adapters"),
     monitorSection("Sandbox Calendar Adapter", calendarAdapterCards.length ? calendarAdapterCards : [record("Sandbox Calendar Adapter", "No sandbox calendar adapter prototype records have been created yet.", [chip("empty")])], "monitor-calendar-adapter"),
     monitorSection("Sandbox Notification Provider", notificationPrototypeCards.length ? notificationPrototypeCards : [record("Sandbox Notification Provider", "No sandbox notification provider prototype records have been created yet.", [chip("empty")])], "monitor-notification-prototype"),
+    monitorSection("Sandbox Payment Provider", paymentPrototypeCards.length ? paymentPrototypeCards : [record("Sandbox Payment Provider", "No sandbox payment provider prototype records have been created yet.", [chip("empty")])], "monitor-payment-prototype"),
     monitorSection("Customer Account History", accountHistoryCards.length ? accountHistoryCards : [record("Customer Account History", "No durable customer account history records have been created yet.", [chip("empty")])], "monitor-account-history"),
     monitorSection("Agent Handoffs", handoffCards, "monitor-handoffs"),
     monitorSection("Notification Outbox", outboxCards, "monitor-notification-outbox"),
@@ -1081,6 +1095,17 @@ function renderNotificationPrototypeOptions() {
     return `<option value="${escapeHtml(prototype.id)}">${escapeHtml(prototype.title)} (${escapeHtml(prototype.status)})</option>`;
   });
   select.innerHTML = prototypeOptions.length ? prototypeOptions.join("") : `<option value="">No sandbox notification provider prototypes yet</option>`;
+  if (submit) submit.disabled = !prototypeOptions.length;
+}
+
+function renderPaymentPrototypeOptions() {
+  const select = byId("payment-prototype-select");
+  const submit = byId("payment-prototype-apply");
+  if (!select) return;
+  const prototypeOptions = (data.paymentProviderPrototypes || []).map((prototype) => {
+    return `<option value="${escapeHtml(prototype.id)}">${escapeHtml(prototype.title)} (${escapeHtml(prototype.status)})</option>`;
+  });
+  select.innerHTML = prototypeOptions.length ? prototypeOptions.join("") : `<option value="">No sandbox payment provider prototypes yet</option>`;
   if (submit) submit.disabled = !prototypeOptions.length;
 }
 
@@ -1208,6 +1233,7 @@ function renderAll() {
   renderProviderAdapterOptions();
   renderCalendarAdapterOptions();
   renderNotificationPrototypeOptions();
+  renderPaymentPrototypeOptions();
   renderQuoteOptions();
   renderReminderControlOptions();
   renderAccessGatewayOptions();
@@ -1712,6 +1738,41 @@ function wireNotificationPrototypeForm() {
   });
 }
 
+function wirePaymentPrototypeForm() {
+  const form = byId("payment-prototype-form");
+  const confirmation = byId("payment-prototype-confirmation");
+  if (!form || !confirmation) return;
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const formData = new FormData(form);
+    const payload = Object.fromEntries(formData.entries());
+    try {
+      const result = recordTools.transitionPaymentProviderPrototypeRecords(data, payload, {
+        now: "2026-06-01T18:35:00.000Z"
+      });
+      data = result.data;
+      persistData({
+        adapterState: "modified-local",
+        recoveryNote: "Sandbox payment provider prototype changed locally; export a ledger snapshot before live payment provider work."
+      });
+      renderAll();
+      confirmation.innerHTML = record(
+        "Sandbox Payment Provider Updated",
+        `${result.records.prototype.title} is ${result.records.prototype.prototypeStatus}; live checkout, invoice sending, capture, refunds, OAuth, secrets, webhooks, provider writes, and customer-visible payment requests remain disabled.`,
+        [statusChip(result.records.prototype.status), chip(result.records.prototype.payloadMode), chip(result.records.prototype.sandboxOnly ? "sandbox-only" : "sandbox-missing")]
+      );
+      form.reset();
+    } catch (error) {
+      confirmation.innerHTML = record(
+        "Sandbox Payment Provider Blocked",
+        error.message || "Sandbox payment provider action could not be applied.",
+        [chip("blocked", "blocked")]
+      );
+    }
+  });
+}
+
 function wireQuotePaymentForm() {
   const form = byId("quote-payment-form");
   const confirmation = byId("quote-payment-confirmation");
@@ -1975,6 +2036,7 @@ function init() {
   wireProviderAdapterForm();
   wireCalendarAdapterForm();
   wireNotificationPrototypeForm();
+  wirePaymentPrototypeForm();
   wireQuotePaymentForm();
   wireReminderControlForm();
   wireAccessGatewayForm();

--- a/web/index.html
+++ b/web/index.html
@@ -343,6 +343,7 @@
         <button type="button" class="mode-button" data-monitor-target="monitor-provider-adapters">Adapters</button>
         <button type="button" class="mode-button" data-monitor-target="monitor-calendar-adapter">Cal Adapter</button>
         <button type="button" class="mode-button" data-monitor-target="monitor-notification-prototype">Notify Proof</button>
+        <button type="button" class="mode-button" data-monitor-target="monitor-payment-prototype">Pay Proof</button>
         <button type="button" class="mode-button" data-monitor-target="monitor-account-history">History</button>
         <button type="button" class="mode-button" data-monitor-target="monitor-controls">Controls</button>
       </div>
@@ -364,6 +365,7 @@
           <button type="button" data-monitor-target="monitor-provider-adapters">Provider Adapters</button>
           <button type="button" data-monitor-target="monitor-calendar-adapter">Sandbox Calendar Adapter</button>
           <button type="button" data-monitor-target="monitor-notification-prototype">Sandbox Notification Provider</button>
+          <button type="button" data-monitor-target="monitor-payment-prototype">Sandbox Payment Provider</button>
           <button type="button" data-monitor-target="monitor-account-history">Customer Account History</button>
           <button type="button" data-monitor-target="monitor-handoffs">Agent Handoffs</button>
           <button type="button" data-monitor-target="monitor-notification-provider">Notification Providers</button>
@@ -649,6 +651,29 @@
               </label>
               <button type="submit" id="notification-prototype-apply">Apply Sandbox Notification Provider Action</button>
             </form>
+            <form id="payment-prototype-form" class="review-console payment-prototype-console">
+              <div class="form-row">
+                <label>
+                  Sandbox Payment Provider
+                  <select name="prototypeId" id="payment-prototype-select" required></select>
+                </label>
+                <label>
+                  Prototype action
+                  <select name="action" id="payment-prototype-action" required>
+                    <option value="generate-preview">Generate local preview</option>
+                    <option value="approve-sandbox">Approve sandbox proof</option>
+                    <option value="mark-reviewed">Mark operator reviewed</option>
+                    <option value="defer">Defer prototype</option>
+                    <option value="block">Block prototype</option>
+                  </select>
+                </label>
+              </div>
+              <label>
+                Prototype note
+                <input name="note" value="Sandbox payment provider reviewed; live checkout, invoice sending, capture, refunds, OAuth, secrets, webhooks, provider writes, and customer-visible payment requests remain disabled." />
+              </label>
+              <button type="submit" id="payment-prototype-apply">Apply Sandbox Payment Provider Action</button>
+            </form>
             <form id="quote-payment-form" class="review-console quote-console">
               <div class="form-row">
                 <label>
@@ -847,6 +872,7 @@
             <div id="provider-adapter-confirmation" class="confirmation"></div>
             <div id="calendar-adapter-confirmation" class="confirmation"></div>
             <div id="notification-prototype-confirmation" class="confirmation"></div>
+            <div id="payment-prototype-confirmation" class="confirmation"></div>
             <div id="quote-payment-confirmation" class="confirmation"></div>
             <div id="reminder-control-confirmation" class="confirmation"></div>
             <div id="access-gateway-confirmation" class="confirmation"></div>

--- a/web/operating-records.js
+++ b/web/operating-records.js
@@ -24,6 +24,7 @@
     "providerAdapterCandidates",
     "calendarAdapterPrototypes",
     "notificationProviderPrototypes",
+    "paymentProviderPrototypes",
     "leads",
     "opportunities",
     "engagements",
@@ -1330,6 +1331,86 @@
     ];
   }
 
+  function defaultPaymentProviderPrototypes() {
+    return [
+      {
+        id: "payment-provider-sandbox-checkout-preview",
+        title: "Payment Provider Sandbox Checkout Preview",
+        providerCandidateId: "provider-adapter-payment-checkout",
+        sourceHandoffId: "payment-provider-checkout-readiness",
+        adapterFamily: "payment",
+        targetProvider: "provider-neutral invoice / checkout",
+        adapterMode: "sandbox-payment-payload-preview",
+        status: "queued",
+        prototypeStatus: "payload-ready",
+        sandboxOnly: true,
+        localOnly: true,
+        livePaymentEnabled: false,
+        liveCheckoutEnabled: false,
+        liveCaptureEnabled: false,
+        liveRefundEnabled: false,
+        invoiceSendEnabled: false,
+        checkoutSessionCreated: false,
+        paymentLinkCreated: false,
+        capturesPayment: false,
+        externalProviderWrite: false,
+        productionEnabled: false,
+        secretsPresent: false,
+        credentialsStored: false,
+        storesCredentials: false,
+        oauthConfigured: false,
+        webhookEnabled: false,
+        customerVisible: false,
+        customerSafe: false,
+        legalReviewRequired: true,
+        taxReviewRequired: true,
+        privacyReviewRequired: true,
+        under19Guarded: true,
+        paymentProcessorSchema: "epoch.quote-payment",
+        payloadMode: "provider-neutral-payment-json-preview",
+        payloadSource: "epoch.quote-payment",
+        payloadEntryCount: 2,
+        readinessChecks: ["provider-candidate-required", "payment-provider-handoff-required", "quote-payment-schema-stable", "legal-review-required", "tax-review-required", "privacy-boundary-required", "under19-eligibility-gate", "sandbox-only-before-go-live", "operator-approval-required", "no-live-payment", "no-secrets", "no-oauth-client", "no-webhooks", "no-provider-writes", "no-checkout-session", "no-payment-capture", "no-refunds", "no-invoice-send", "no-customer-visible-payment-request"],
+        payloadPreview: [
+          {
+            uid: "epoch-payment-preview-eiken-monthly",
+            title: "Premium EIKEN Writing Review payment preview",
+            provider: "provider-neutral",
+            amountJpy: 45000,
+            currency: "JPY",
+            customerName: "Adult writing student",
+            packageId: "pkg-eiken-writing-monthly",
+            source: "opportunity:opp-001",
+            status: "preview-only",
+            paymentStatus: "not-created",
+            checkoutSession: "not-created",
+            customerSafe: true
+          },
+          {
+            uid: "epoch-payment-preview-under19-gate",
+            title: "Under-19 compatibility assessment blocked payment preview",
+            provider: "provider-neutral",
+            amountJpy: 65000,
+            currency: "JPY",
+            customerName: "Under-19 compatibility review",
+            packageId: "pkg-under19-assessment",
+            source: "package:pkg-under19-assessment",
+            status: "blocked-preview-only",
+            paymentStatus: "guardian-consent-required",
+            checkoutSession: "not-created",
+            customerSafe: true
+          }
+        ],
+        blockers: ["No legal/tax/privacy review signoff", "No checkout credential storage", "No webhook signing secret", "No live payment capture or refund path", "Under-19 payment requests remain blocked before guardian consent"],
+        nextActionAt: "2026-06-04T12:00:00+09:00",
+        createdAt: "2026-06-02T07:00:00+09:00",
+        updatedAt: "2026-06-02T07:00:00+09:00",
+        receiptIds: ["receipt-payment-provider-prototype-seed"],
+        notes: "Local payment payload preview only; live checkout, invoice sending, capture, refunds, OAuth, secrets, webhooks, provider writes, and customer-visible payment requests remain disabled."
+      }
+    ];
+  }
+
   function normalizedOperatingData(data) {
     const nextData = cloneData(data || {});
     for (const collection of ledgerCollections) {
@@ -1368,6 +1449,9 @@
     }
     if (!Array.isArray(nextData.notificationProviderPrototypes) || !nextData.notificationProviderPrototypes.length) {
       nextData.notificationProviderPrototypes = defaultNotificationProviderPrototypes();
+    }
+    if (!Array.isArray(nextData.paymentProviderPrototypes) || !nextData.paymentProviderPrototypes.length) {
+      nextData.paymentProviderPrototypes = defaultPaymentProviderPrototypes();
     }
     nextData.customerAccountHistories = reconcileCustomerAccountHistories(nextData);
     if (!nextData.accessPosture || typeof nextData.accessPosture !== "object") {
@@ -6443,6 +6527,441 @@
     };
   }
 
+  function paymentProviderPayloadPreview(currentData, limit = 4) {
+    const data = normalizedOperatingData(currentData);
+    const customersById = data.customers.reduce((memo, customer) => {
+      memo[customer.id] = customer;
+      return memo;
+    }, {});
+    const leadsById = data.leads.reduce((memo, lead) => {
+      memo[lead.id] = lead;
+      return memo;
+    }, {});
+    const packagesById = data.offerPackages.reduce((memo, offerPackage) => {
+      memo[offerPackage.id] = offerPackage;
+      return memo;
+    }, {});
+    const quoteItems = data.quotes.map((quote) => {
+      const customer = customersById[quote.customerId] || {};
+      const offerPackage = packagesById[quote.packageId] || {};
+      return {
+        uid: `epoch-payment-quote-${clean(quote.id)}`,
+        title: clean(quote.title) || `${clean(offerPackage.name) || "Service"} payment preview`,
+        provider: "provider-neutral",
+        amountJpy: Number(quote.amountJpy || offerPackage.priceJpy || 0),
+        currency: clean(quote.currency) || "JPY",
+        customerId: clean(quote.customerId),
+        customerName: clean(customer.name) || "customer",
+        packageId: clean(quote.packageId),
+        source: `quote:${clean(quote.id)}`,
+        status: "preview-only",
+        paymentStatus: clean(quote.paymentStatus) || "not-created",
+        checkoutSession: "not-created",
+        under19Guarded: quote.under19 === true || quote.guardianConsentRequired === true,
+        customerSafe: true
+      };
+    });
+    const opportunityItems = data.opportunities.map((opportunity) => {
+      const lead = leadsById[opportunity.leadId] || {};
+      const offerPackage = packagesById[opportunity.packageId] || {};
+      const under19Guarded = clean(offerPackage.routing) === "compatibility-required" || clean(lead.name).toLowerCase().includes("under-19");
+      return {
+        uid: `epoch-payment-opportunity-${clean(opportunity.id)}`,
+        title: `${clean(offerPackage.name) || clean(opportunity.packageId) || "Service"} payment preview`,
+        provider: "provider-neutral",
+        amountJpy: Number(opportunity.estimatedValueJpy || offerPackage.priceJpy || 0),
+        currency: "JPY",
+        customerId: "",
+        customerName: clean(lead.name) || "prospect",
+        packageId: clean(opportunity.packageId),
+        source: `opportunity:${clean(opportunity.id)}`,
+        status: under19Guarded ? "blocked-preview-only" : "preview-only",
+        paymentStatus: under19Guarded ? "guardian-consent-required" : "not-created",
+        checkoutSession: "not-created",
+        under19Guarded,
+        customerSafe: true
+      };
+    });
+    const packageItems = data.offerPackages
+      .filter((offerPackage) => clean(offerPackage.routing) === "compatibility-required")
+      .map((offerPackage) => ({
+        uid: `epoch-payment-package-${clean(offerPackage.id)}`,
+        title: `${clean(offerPackage.name) || "Compatibility package"} blocked payment preview`,
+        provider: "provider-neutral",
+        amountJpy: Number(offerPackage.priceJpy || 0),
+        currency: "JPY",
+        customerId: "",
+        customerName: "Under-19 compatibility review",
+        packageId: clean(offerPackage.id),
+        source: `package:${clean(offerPackage.id)}`,
+        status: "blocked-preview-only",
+        paymentStatus: "guardian-consent-required",
+        checkoutSession: "not-created",
+        under19Guarded: true,
+        customerSafe: true
+      }));
+
+    return (quoteItems.length ? quoteItems : [...opportunityItems, ...packageItems]).slice(0, limit);
+  }
+
+  function summarizePaymentProviderPrototypeState(currentData, options = {}) {
+    const data = normalizedOperatingData(currentData);
+    const providerAdapters = options.providerAdapters || summarizeProviderAdapterSelectionState(data);
+    const paymentProvider = options.paymentProvider || summarizePaymentProviderState(data);
+    const candidateById = providerAdapters.candidates.reduce((memo, candidate) => {
+      memo[candidate.id] = candidate;
+      return memo;
+    }, {});
+    const handoffById = paymentProvider.handoffs.reduce((memo, handoff) => {
+      memo[handoff.id] = handoff;
+      return memo;
+    }, {});
+    const requiredChecks = ["provider-candidate-required", "payment-provider-handoff-required", "quote-payment-schema-stable", "legal-review-required", "tax-review-required", "privacy-boundary-required", "under19-eligibility-gate", "sandbox-only-before-go-live", "operator-approval-required", "no-live-payment", "no-secrets", "no-oauth-client", "no-webhooks", "no-provider-writes", "no-checkout-session", "no-payment-capture", "no-refunds", "no-invoice-send", "no-customer-visible-payment-request"];
+    const prototypes = data.paymentProviderPrototypes.map((prototype) => {
+      const providerCandidateId = clean(prototype.providerCandidateId);
+      const sourceHandoffId = clean(prototype.sourceHandoffId);
+      const candidate = candidateById[providerCandidateId] || null;
+      const handoff = handoffById[sourceHandoffId] || null;
+      const readinessChecks = Array.isArray(prototype.readinessChecks) ? prototype.readinessChecks : [];
+      const payloadPreview = Array.isArray(prototype.payloadPreview) ? prototype.payloadPreview : [];
+      const receiptIds = Array.isArray(prototype.receiptIds) ? prototype.receiptIds : [];
+      const blockers = Array.isArray(prototype.blockers) ? prototype.blockers : [];
+      const livePaymentEnabled = prototype.livePaymentEnabled === true;
+      const liveCheckoutEnabled = prototype.liveCheckoutEnabled === true;
+      const liveCaptureEnabled = prototype.liveCaptureEnabled === true;
+      const liveRefundEnabled = prototype.liveRefundEnabled === true;
+      const invoiceSendEnabled = prototype.invoiceSendEnabled === true;
+      const checkoutSessionCreated = prototype.checkoutSessionCreated === true;
+      const paymentLinkCreated = prototype.paymentLinkCreated === true;
+      const capturesPayment = prototype.capturesPayment === true;
+      const externalProviderWrite = prototype.externalProviderWrite === true;
+      const productionEnabled = prototype.productionEnabled === true;
+      const secretsPresent = prototype.secretsPresent === true;
+      const credentialsStored = prototype.credentialsStored === true;
+      const storesCredentials = prototype.storesCredentials === true;
+      const oauthConfigured = prototype.oauthConfigured === true;
+      const webhookEnabled = prototype.webhookEnabled === true;
+      const customerVisible = prototype.customerVisible === true;
+      const legalReviewRequired = prototype.legalReviewRequired !== false;
+      const taxReviewRequired = prototype.taxReviewRequired !== false;
+      const privacyReviewRequired = prototype.privacyReviewRequired !== false;
+      const under19Guarded = prototype.under19Guarded !== false;
+      const violations = [];
+
+      if (clean(prototype.adapterFamily || "payment") !== "payment") {
+        violations.push("Payment provider prototype must stay in the payment adapter family.");
+      }
+      if (!candidate || candidate.providerFamily !== "payment") {
+        violations.push("Payment provider prototype must link to a payment provider adapter candidate.");
+      } else if (candidate.violations.length) {
+        violations.push("Linked payment provider adapter candidate has readiness violations.");
+      }
+      if (!handoff) {
+        violations.push("Payment provider prototype must link to a payment provider handoff.");
+      } else if (handoff.violations.length) {
+        violations.push("Linked payment provider handoff has readiness violations.");
+      }
+      if (prototype.sandboxOnly === false || prototype.localOnly === false) {
+        violations.push("Payment provider prototype must remain sandbox-only and local-only.");
+      }
+      if (livePaymentEnabled || liveCheckoutEnabled || liveCaptureEnabled || liveRefundEnabled || invoiceSendEnabled || checkoutSessionCreated || paymentLinkCreated || capturesPayment || externalProviderWrite || productionEnabled) {
+        violations.push("Payment provider prototype cannot enable live checkout, invoice sending, payment capture, refunds, production behavior, payment links, checkout sessions, or provider writes.");
+      }
+      if (secretsPresent || credentialsStored || storesCredentials || oauthConfigured || webhookEnabled) {
+        violations.push("Payment provider prototype cannot store secrets, credentials, OAuth clients, or webhooks.");
+      }
+      if (customerVisible) {
+        violations.push("Payment provider prototype must remain internal and not create customer-visible payment requests.");
+      }
+      if (!legalReviewRequired || !taxReviewRequired || !privacyReviewRequired) {
+        violations.push("Payment provider prototype must keep legal, tax, and privacy review requirements visible.");
+      }
+      if (!under19Guarded) {
+        violations.push("Payment provider prototype must preserve under-19 eligibility gating.");
+      }
+      for (const required of requiredChecks) {
+        if (!readinessChecks.includes(required)) {
+          violations.push(`Payment provider prototype must include ${required}.`);
+        }
+      }
+      if (!payloadPreview.length) violations.push("Payment provider prototype must include a local payment payload preview.");
+      if (!blockers.length) violations.push("Payment provider prototype must define blockers before live payment provider work.");
+      if (clean(prototype.status) === "complete" && !receiptIds.length) {
+        violations.push("Completed payment provider prototype requires a receipt trail.");
+      }
+
+      return {
+        id: clean(prototype.id),
+        title: clean(prototype.title) || "Payment Provider Prototype",
+        providerCandidateId,
+        sourceHandoffId,
+        adapterFamily: clean(prototype.adapterFamily) || "payment",
+        targetProvider: clean(prototype.targetProvider) || candidate?.targetProvider || handoff?.targetProvider || "provider-neutral payment",
+        adapterMode: clean(prototype.adapterMode) || "sandbox-payment-payload-preview",
+        status: clean(prototype.status) || "planned",
+        prototypeStatus: clean(prototype.prototypeStatus) || "payload-pending",
+        sandboxOnly: prototype.sandboxOnly !== false,
+        localOnly: prototype.localOnly !== false,
+        livePaymentEnabled,
+        liveCheckoutEnabled,
+        liveCaptureEnabled,
+        liveRefundEnabled,
+        invoiceSendEnabled,
+        checkoutSessionCreated,
+        paymentLinkCreated,
+        capturesPayment,
+        externalProviderWrite,
+        productionEnabled,
+        secretsPresent,
+        credentialsStored,
+        storesCredentials,
+        oauthConfigured,
+        webhookEnabled,
+        customerVisible,
+        customerSafe: prototype.customerSafe === true,
+        legalReviewRequired,
+        taxReviewRequired,
+        privacyReviewRequired,
+        under19Guarded,
+        paymentProcessorSchema: clean(prototype.paymentProcessorSchema) || "epoch.quote-payment",
+        payloadMode: clean(prototype.payloadMode) || "provider-neutral-payment-json-preview",
+        payloadSource: clean(prototype.payloadSource) || "epoch.quote-payment",
+        payloadEntryCount: payloadPreview.length,
+        readinessChecks,
+        payloadPreview,
+        blockers,
+        nextActionAt: clean(prototype.nextActionAt),
+        createdAt: clean(prototype.createdAt),
+        updatedAt: clean(prototype.updatedAt),
+        receiptIds,
+        notes: clean(prototype.notes) || "No sandbox payment provider prototype note recorded.",
+        violations
+      };
+    });
+    const violations = prototypes.flatMap((prototype) => prototype.violations.map((detail) => `${prototype.title}: ${detail}`));
+
+    return {
+      schema: "epoch.payment-provider-prototype",
+      prototypeCount: prototypes.length,
+      payloadReady: prototypes.filter((prototype) => ["payload-ready", "sandbox-approved", "operator-reviewed"].includes(prototype.prototypeStatus)).length,
+      sandboxOnly: prototypes.filter((prototype) => prototype.sandboxOnly).length,
+      localOnly: prototypes.filter((prototype) => prototype.localOnly).length,
+      noLivePayment: prototypes.filter((prototype) => !prototype.livePaymentEnabled && !prototype.liveCheckoutEnabled && !prototype.liveCaptureEnabled && !prototype.liveRefundEnabled && !prototype.invoiceSendEnabled && !prototype.checkoutSessionCreated && !prototype.paymentLinkCreated && !prototype.capturesPayment && !prototype.externalProviderWrite && !prototype.productionEnabled).length,
+      noSecrets: prototypes.filter((prototype) => !prototype.secretsPresent && !prototype.credentialsStored && !prototype.storesCredentials && !prototype.oauthConfigured && !prototype.webhookEnabled).length,
+      noCustomerVisiblePayment: prototypes.filter((prototype) => !prototype.customerVisible).length,
+      noPaymentCapture: prototypes.filter((prototype) => !prototype.capturesPayment && !prototype.liveCaptureEnabled).length,
+      legalTaxPrivacyReady: prototypes.filter((prototype) => prototype.legalReviewRequired && prototype.taxReviewRequired && prototype.privacyReviewRequired).length,
+      under19Guarded: prototypes.filter((prototype) => prototype.under19Guarded).length,
+      candidateLinked: prototypes.filter((prototype) => candidateById[prototype.providerCandidateId]?.providerFamily === "payment").length,
+      handoffLinked: prototypes.filter((prototype) => handoffById[prototype.sourceHandoffId]).length,
+      payloadEntries: prototypes.reduce((total, prototype) => total + prototype.payloadEntryCount, 0),
+      status: violations.length ? "blocked" : "ready",
+      violations,
+      prototypes
+    };
+  }
+
+  function createPaymentProviderPrototypeRecords(currentData, input = {}, options = {}) {
+    const nextData = normalizedOperatingData(currentData);
+    const now = options.now ? new Date(options.now) : new Date();
+    const timezone = nextData.timezone || "Asia/Tokyo";
+    const nowText = withTimezone(now.toISOString(), timezone);
+    const candidateId = clean(input.providerCandidateId || input.candidateId) || clean(nextData.providerAdapterCandidates.find((item) => clean(item.providerFamily) === "payment")?.id);
+    const candidate = nextData.providerAdapterCandidates.find((item) => clean(item.id) === candidateId);
+    if (!candidate || clean(candidate.providerFamily) !== "payment") throw new Error("payment provider adapter candidate is required");
+    if (candidate.liveApiCalls || candidate.productionEnabled || candidate.externalProviderWrite || candidate.secretsPresent || candidate.credentialsStored || candidate.oauthConfigured || candidate.webhookEnabled) {
+      throw new Error("payment provider adapter candidate is not safe for sandbox prototype");
+    }
+    const sourceHandoffId = clean(input.sourceHandoffId || input.handoffId) || clean((Array.isArray(candidate.sourceHandoffIds) ? candidate.sourceHandoffIds[0] : "") || nextData.paymentProviderHandoffs[0]?.id);
+    const sourceHandoff = nextData.paymentProviderHandoffs.find((item) => clean(item.id) === sourceHandoffId);
+    if (!sourceHandoff) throw new Error("payment provider handoff is required for sandbox prototype");
+    if (sourceHandoff.livePaymentEnabled || sourceHandoff.externalProviderWrite || sourceHandoff.storesCredentials || sourceHandoff.webhookEnabled || sourceHandoff.capturesPayment || sourceHandoff.customerVisible) {
+      throw new Error("payment provider handoff is not safe for sandbox prototype");
+    }
+    const payloadPreview = paymentProviderPayloadPreview(nextData, Number(input.payloadLimit) || 4);
+    if (!payloadPreview.length) throw new Error("payment records have no quote or opportunity payload to preview");
+    const prototype = {
+      id: clean(input.id) || `payment-provider-prototype-${stamp(now)}-${nextData.paymentProviderPrototypes.length + 1}`,
+      title: clean(input.title) || `${candidate.targetProvider || "Payment"} Sandbox Payment Provider Prototype`,
+      providerCandidateId: candidate.id,
+      sourceHandoffId: sourceHandoff.id,
+      adapterFamily: "payment",
+      targetProvider: clean(input.targetProvider) || candidate.targetProvider || sourceHandoff.targetProvider || "provider-neutral payment",
+      adapterMode: clean(input.adapterMode) || "sandbox-payment-payload-preview",
+      status: clean(input.status) || "queued",
+      prototypeStatus: clean(input.prototypeStatus) || "payload-ready",
+      sandboxOnly: true,
+      localOnly: true,
+      livePaymentEnabled: false,
+      liveCheckoutEnabled: false,
+      liveCaptureEnabled: false,
+      liveRefundEnabled: false,
+      invoiceSendEnabled: false,
+      checkoutSessionCreated: false,
+      paymentLinkCreated: false,
+      capturesPayment: false,
+      externalProviderWrite: false,
+      productionEnabled: false,
+      secretsPresent: false,
+      credentialsStored: false,
+      storesCredentials: false,
+      oauthConfigured: false,
+      webhookEnabled: false,
+      customerVisible: false,
+      customerSafe: false,
+      legalReviewRequired: true,
+      taxReviewRequired: true,
+      privacyReviewRequired: true,
+      under19Guarded: true,
+      paymentProcessorSchema: "epoch.quote-payment",
+      payloadMode: clean(input.payloadMode) || "provider-neutral-payment-json-preview",
+      payloadSource: "epoch.quote-payment",
+      payloadEntryCount: payloadPreview.length,
+      readinessChecks: ["provider-candidate-required", "payment-provider-handoff-required", "quote-payment-schema-stable", "legal-review-required", "tax-review-required", "privacy-boundary-required", "under19-eligibility-gate", "sandbox-only-before-go-live", "operator-approval-required", "no-live-payment", "no-secrets", "no-oauth-client", "no-webhooks", "no-provider-writes", "no-checkout-session", "no-payment-capture", "no-refunds", "no-invoice-send", "no-customer-visible-payment-request"],
+      payloadPreview,
+      blockers: Array.isArray(input.blockers) ? input.blockers : ["No legal/tax/privacy review signoff", "No checkout credential storage", "No webhook signing secret", "No live payment capture or refund path", "Under-19 payment requests remain blocked before guardian consent"],
+      nextActionAt: withTimezone(input.nextActionAt, timezone) || nowText,
+      createdAt: nowText,
+      updatedAt: nowText,
+      receiptIds: [],
+      notes: clean(input.note) || "Sandbox payment provider prototype created from EPOCH quote/payment readiness records without live provider behavior."
+    };
+    const receipt = {
+      id: `receipt-payment-provider-prototype-${stamp(now)}`,
+      kind: "payment-provider-prototype",
+      status: "complete",
+      createdAt: nowText,
+      note: `${prototype.title}: local payment payload preview created without live checkout, invoice sending, capture, refunds, OAuth, secrets, webhooks, provider writes, or customer-visible payment requests.`
+    };
+    const healthCheck = {
+      id: `monitor-check-payment-prototype-${stamp(now)}`,
+      title: "Sandbox Payment Provider Prototype",
+      status: "complete",
+      target: "monitor-payment-prototype",
+      effect: "payment-provider-sandbox-proof",
+      createdAt: nowText,
+      summary: `${prototype.title} generated ${payloadPreview.length} local payment payload preview items from quote/payment readiness records.`,
+      receiptId: receipt.id,
+      visibility: "internal",
+      customerVisible: false
+    };
+    prototype.receiptIds.push(receipt.id);
+    nextData.paymentProviderPrototypes.unshift(prototype);
+    nextData.receipts.unshift(receipt);
+    nextData.monitorHealthChecks.unshift(healthCheck);
+
+    return {
+      data: nextData,
+      records: {
+        prototype,
+        receipt,
+        healthCheck
+      }
+    };
+  }
+
+  function transitionPaymentProviderPrototypeRecords(currentData, input = {}, options = {}) {
+    const nextData = normalizedOperatingData(currentData);
+    const now = options.now ? new Date(options.now) : new Date();
+    const timezone = nextData.timezone || "Asia/Tokyo";
+    const nowText = withTimezone(now.toISOString(), timezone);
+    const prototype = nextData.paymentProviderPrototypes.find((item) => clean(item.id) === clean(input.prototypeId || input.id));
+    if (!prototype) throw new Error("Select a sandbox payment provider prototype before applying an action.");
+    const action = clean(input.action) || "generate-preview";
+    const note = clean(input.note) || "Sandbox payment provider prototype reviewed without live provider behavior.";
+    const ensureChecks = (checks) => {
+      prototype.readinessChecks = Array.isArray(prototype.readinessChecks) ? prototype.readinessChecks : [];
+      for (const check of checks) {
+        if (!prototype.readinessChecks.includes(check)) prototype.readinessChecks.push(check);
+      }
+    };
+
+    if (action === "generate-preview") {
+      prototype.payloadPreview = paymentProviderPayloadPreview(nextData, Number(input.payloadLimit) || 4);
+      prototype.payloadEntryCount = prototype.payloadPreview.length;
+      prototype.status = "queued";
+      prototype.prototypeStatus = "payload-ready";
+    } else if (action === "approve-sandbox") {
+      prototype.status = "approved";
+      prototype.prototypeStatus = "sandbox-approved";
+    } else if (action === "mark-reviewed") {
+      prototype.status = "complete";
+      prototype.prototypeStatus = "operator-reviewed";
+    } else if (action === "defer") {
+      prototype.status = "waiting";
+      prototype.prototypeStatus = "deferred";
+    } else if (action === "block") {
+      prototype.status = "blocked";
+      prototype.prototypeStatus = "blocked";
+    } else {
+      throw new Error("unsupported sandbox payment provider action");
+    }
+
+    ensureChecks(["provider-candidate-required", "payment-provider-handoff-required", "quote-payment-schema-stable", "legal-review-required", "tax-review-required", "privacy-boundary-required", "under19-eligibility-gate", "sandbox-only-before-go-live", "operator-approval-required", "no-live-payment", "no-secrets", "no-oauth-client", "no-webhooks", "no-provider-writes", "no-checkout-session", "no-payment-capture", "no-refunds", "no-invoice-send", "no-customer-visible-payment-request"]);
+    prototype.adapterFamily = "payment";
+    prototype.sandboxOnly = true;
+    prototype.localOnly = true;
+    prototype.livePaymentEnabled = false;
+    prototype.liveCheckoutEnabled = false;
+    prototype.liveCaptureEnabled = false;
+    prototype.liveRefundEnabled = false;
+    prototype.invoiceSendEnabled = false;
+    prototype.checkoutSessionCreated = false;
+    prototype.paymentLinkCreated = false;
+    prototype.capturesPayment = false;
+    prototype.externalProviderWrite = false;
+    prototype.productionEnabled = false;
+    prototype.secretsPresent = false;
+    prototype.credentialsStored = false;
+    prototype.storesCredentials = false;
+    prototype.oauthConfigured = false;
+    prototype.webhookEnabled = false;
+    prototype.customerVisible = false;
+    prototype.customerSafe = false;
+    prototype.legalReviewRequired = true;
+    prototype.taxReviewRequired = true;
+    prototype.privacyReviewRequired = true;
+    prototype.under19Guarded = true;
+    prototype.paymentProcessorSchema = "epoch.quote-payment";
+    prototype.payloadSource = "epoch.quote-payment";
+    prototype.updatedAt = nowText;
+    prototype.notes = note;
+
+    const receipt = {
+      id: `receipt-payment-provider-prototype-${stamp(now)}`,
+      kind: "payment-provider-prototype",
+      status: prototype.status === "blocked" ? "blocked" : "complete",
+      createdAt: nowText,
+      note: `${prototype.title}: ${action} recorded without live checkout, invoice sending, capture, refunds, OAuth, secrets, webhooks, provider writes, or customer-visible payment requests. ${note}`
+    };
+    const healthCheck = {
+      id: `monitor-check-payment-prototype-${stamp(now)}`,
+      title: "Sandbox Payment Provider Prototype",
+      status: prototype.status === "blocked" ? "blocked" : "complete",
+      target: "monitor-payment-prototype",
+      effect: "payment-provider-sandbox-proof",
+      createdAt: nowText,
+      summary: `${prototype.title} is ${prototype.prototypeStatus}; payment behavior remains sandbox/local only.`,
+      receiptId: receipt.id,
+      visibility: "internal",
+      customerVisible: false
+    };
+
+    prototype.receiptIds = Array.isArray(prototype.receiptIds) ? prototype.receiptIds : [];
+    prototype.receiptIds.push(receipt.id);
+    nextData.receipts.unshift(receipt);
+    nextData.monitorHealthChecks.unshift(healthCheck);
+
+    return {
+      data: nextData,
+      records: {
+        prototype,
+        receipt,
+        healthCheck
+      }
+    };
+  }
+
   function summarizeMemoryState(currentData, options = {}) {
     const data = normalizedOperatingData(currentData);
     const nowText = clean(options.now) || "2026-06-01T12:00:00+09:00";
@@ -6479,6 +6998,8 @@
     const providerAdapters = summarizeProviderAdapterSelectionState(data);
     const calendarExport = createCalendarExport(data, { now: nowText });
     const calendarAdapter = summarizeCalendarAdapterPrototypeState(data, { now: nowText, calendarExport, providerAdapters });
+    const paymentProvider = summarizePaymentProviderState(data, { quotes });
+    const paymentPrototype = summarizePaymentProviderPrototypeState(data, { providerAdapters, paymentProvider });
     const timeline = monitorTimelineItems(data);
     const terminalStatuses = new Set(["complete", "sent", "paid-recorded", "declined", "returned", "canceled", "accepted", "rejected", "rolled-back"]);
     const queue = timeline.filter((item) => ["waiting", "deferred", "draft", "presented", "queued", "submitted", "reviewing", "overdue", "blocked", "proposed", "approved", "dispatched", "acknowledged", "in-progress", "failed", "snoozed", "retry-ready", "payment-ready", "payment-blocked", "unavailable"].includes(item.status));
@@ -6509,6 +7030,8 @@
       providerAdapterReady: providerAdapters.readyCandidates,
       calendarAdapterPrototypes: calendarAdapter.prototypeCount,
       calendarAdapterPayloadReady: calendarAdapter.payloadReady,
+      paymentProviderPrototypes: paymentPrototype.prototypeCount,
+      paymentPrototypePayloadReady: paymentPrototype.payloadReady,
       copyComplianceViolations: marketing.copyViolations
     };
     const summaryByKey = {
@@ -6516,7 +7039,7 @@
       queue: `${baseSummary.queue} queued records`,
       "visible-updates": `${baseSummary.visibleUpdates} visible updates`,
       pipeline: `${revenue.pipelineCount} opportunities; ${baseSummary.pipelineValueJpy} JPY pipeline`,
-      marketing: `${marketing.ready} ready campaigns; ${marketingConversion.readyEvents} KPI events; ${providerAdapters.readyCandidates} provider candidates; ${calendarAdapter.payloadReady} calendar prototypes; ${marketing.copyViolations} copy policy violations`
+      marketing: `${marketing.ready} ready campaigns; ${marketingConversion.readyEvents} KPI events; ${providerAdapters.readyCandidates} provider candidates; ${calendarAdapter.payloadReady} calendar prototypes; ${paymentPrototype.payloadReady} payment prototypes; ${marketing.copyViolations} copy policy violations`
     };
     const routes = data.routePlacements.map((route) => ({
       id: clean(route.id),
@@ -7498,6 +8021,7 @@
       ...(currentData.providerAdapterCandidates || []).map((item) => ({ kind: "provider adapter", id: item.id, title: item.title, status: item.status || item.readinessStatus, time: item.nextActionAt || item.updatedAt || item.createdAt, owner: item.providerFamily || item.targetProvider || "provider" })),
       ...(currentData.calendarAdapterPrototypes || []).map((item) => ({ kind: "calendar adapter", id: item.id, title: item.title, status: item.status || item.prototypeStatus, time: item.nextActionAt || item.updatedAt || item.createdAt, owner: item.targetProvider || item.adapterMode || "calendar" })),
       ...(currentData.notificationProviderPrototypes || []).map((item) => ({ kind: "notification prototype", id: item.id, title: item.title, status: item.status || item.prototypeStatus, time: item.nextActionAt || item.updatedAt || item.createdAt, owner: item.targetProvider || item.adapterMode || "notification" })),
+      ...(currentData.paymentProviderPrototypes || []).map((item) => ({ kind: "payment prototype", id: item.id, title: item.title, status: item.status || item.prototypeStatus, time: item.nextActionAt || item.updatedAt || item.createdAt, owner: item.targetProvider || item.adapterMode || "payment" })),
       ...(currentData.customerAccountHistories || []).map((item) => ({ kind: "account history", id: item.id, title: item.displayName || item.id, status: item.status, time: item.updatedAt || item.reviewedAt, owner: item.visibility || "customer history" })),
       ...currentData.workPlans.map((item) => ({ kind: "agent work plan", id: item.id, title: item.title, status: item.status, time: item.dueAt, owner: item.approvalStatus || item.owner || "approval pending" })),
       ...currentData.agentHandoffs.map((item) => ({ kind: "agent handoff", id: item.id, title: item.title, status: item.status, time: item.nextActionAt, owner: item.approvalStatus || "approval pending" })),
@@ -7541,6 +8065,7 @@
     const marketing = summarizeMarketingState(data);
     const marketingConversion = summarizeMarketingConversionState(data);
     const providerAdapters = summarizeProviderAdapterSelectionState(data);
+    const paymentPrototype = summarizePaymentProviderPrototypeState(data, { providerAdapters, paymentProvider });
     const calendarExport = createCalendarExport(data, { now: nowText });
     const calendarAdapter = summarizeCalendarAdapterPrototypeState(data, { now: nowText, calendarExport, providerAdapters });
     const notificationPrototype = summarizeNotificationProviderPrototypeState(data, { providerAdapters, notificationProvider });
@@ -7594,6 +8119,10 @@
       if (activeStatuses.has(item.status) && !queue.some((entry) => entry.id === item.id)) queue.push(item);
     }
     for (const item of timeline.filter((entry) => entry.kind === "payment provider").slice(0, 4)) {
+      if (!visibleTimeline.some((entry) => entry.id === item.id)) visibleTimeline.push(item);
+      if (activeStatuses.has(item.status) && !queue.some((entry) => entry.id === item.id)) queue.push(item);
+    }
+    for (const item of timeline.filter((entry) => entry.kind === "payment prototype").slice(0, 4)) {
       if (!visibleTimeline.some((entry) => entry.id === item.id)) visibleTimeline.push(item);
       if (activeStatuses.has(item.status) && !queue.some((entry) => entry.id === item.id)) queue.push(item);
     }
@@ -7777,6 +8306,14 @@
         detail: paymentProvider.violations[0]
       });
     }
+    if (paymentPrototype.violations.length) {
+      risks.push({
+        id: "payment-provider-prototype-violation",
+        severity: "high",
+        title: "Sandbox Payment Provider",
+        detail: paymentPrototype.violations[0]
+      });
+    }
     if (authSession.violations.length) {
       risks.push({
         id: "auth-session-role-violation",
@@ -7881,6 +8418,17 @@
         paymentEligibilityReady: paymentProvider.eligibilityReady,
         paymentProviderNoLivePayment: paymentProvider.noLivePayment,
         paymentProviderViolations: paymentProvider.violations.length,
+        paymentProviderPrototypes: paymentPrototype.prototypeCount,
+        paymentPrototypePayloadReady: paymentPrototype.payloadReady,
+        paymentPrototypeSandboxOnly: paymentPrototype.sandboxOnly,
+        paymentPrototypeLocalOnly: paymentPrototype.localOnly,
+        paymentPrototypeNoLivePayment: paymentPrototype.noLivePayment,
+        paymentPrototypeNoSecrets: paymentPrototype.noSecrets,
+        paymentPrototypeNoCustomerVisiblePayment: paymentPrototype.noCustomerVisiblePayment,
+        paymentPrototypeNoPaymentCapture: paymentPrototype.noPaymentCapture,
+        paymentPrototypeLegalTaxPrivacyReady: paymentPrototype.legalTaxPrivacyReady,
+        paymentPrototypeUnder19Guarded: paymentPrototype.under19Guarded,
+        paymentPrototypeViolations: paymentPrototype.violations.length,
         authSessionRoleHandoffs: authSession.handoffCount,
         authPublicReady: authSession.publicReady,
         authCustomerReady: authSession.customerReady,
@@ -7988,6 +8536,7 @@
       notificationProvider,
       notificationPrototype,
       paymentProvider,
+      paymentPrototype,
       authSession,
       accountHistory,
       quotes,
@@ -8039,6 +8588,7 @@
     const providerAdapters = summarizeProviderAdapterSelectionState(data);
     const calendarAdapter = summarizeCalendarAdapterPrototypeState(data, { now: now.toISOString(), calendarExport, providerAdapters });
     const notificationPrototype = summarizeNotificationProviderPrototypeState(data, { providerAdapters, notificationProvider });
+    const paymentPrototype = summarizePaymentProviderPrototypeState(data, { providerAdapters, paymentProvider });
     const routePlacement = summarizeRoutePlacementState(data, { now: now.toISOString() });
     const accessGateway = summarizeAccessGatewayState(data, { now: now.toISOString(), routePlacement });
     const librarySync = summarizeLibrarySyncState(data, { now: now.toISOString(), persistence });
@@ -8060,6 +8610,7 @@
       notificationProvider,
       notificationPrototype,
       paymentProvider,
+      paymentPrototype,
       authSession,
       accountHistory,
       marketingConversion,
@@ -8105,6 +8656,8 @@
     transitionCalendarAdapterPrototypeRecords,
     createNotificationProviderPrototypeRecords,
     transitionNotificationProviderPrototypeRecords,
+    createPaymentProviderPrototypeRecords,
+    transitionPaymentProviderPrototypeRecords,
     createCustomerAccountHistoryRecords,
     createQuoteEstimateRecords,
     transitionQuoteEstimateRecords,
@@ -8146,6 +8699,7 @@
     summarizeProviderAdapterSelectionState,
     summarizeCalendarAdapterPrototypeState,
     summarizeNotificationProviderPrototypeState,
+    summarizePaymentProviderPrototypeState,
     summarizeCustomerAccountHistoryState,
     summarizeAccessPosture,
     summarizeMemoryState,

--- a/web/seed-data.js
+++ b/web/seed-data.js
@@ -1489,6 +1489,83 @@ window.EPOCH_SEED_DATA = {
       "notes": "Local message preview only; live email, LINE, SMS, NEXUS, webhooks, credentials, provider writes, and customer-visible sends remain disabled."
     }
   ],
+  "paymentProviderPrototypes": [
+    {
+      "id": "payment-provider-sandbox-checkout-preview",
+      "title": "Payment Provider Sandbox Checkout Preview",
+      "providerCandidateId": "provider-adapter-payment-checkout",
+      "sourceHandoffId": "payment-provider-checkout-readiness",
+      "adapterFamily": "payment",
+      "targetProvider": "provider-neutral invoice / checkout",
+      "adapterMode": "sandbox-payment-payload-preview",
+      "status": "queued",
+      "prototypeStatus": "payload-ready",
+      "sandboxOnly": true,
+      "localOnly": true,
+      "livePaymentEnabled": false,
+      "liveCheckoutEnabled": false,
+      "liveCaptureEnabled": false,
+      "liveRefundEnabled": false,
+      "invoiceSendEnabled": false,
+      "checkoutSessionCreated": false,
+      "paymentLinkCreated": false,
+      "capturesPayment": false,
+      "externalProviderWrite": false,
+      "productionEnabled": false,
+      "secretsPresent": false,
+      "credentialsStored": false,
+      "storesCredentials": false,
+      "oauthConfigured": false,
+      "webhookEnabled": false,
+      "customerVisible": false,
+      "customerSafe": false,
+      "legalReviewRequired": true,
+      "taxReviewRequired": true,
+      "privacyReviewRequired": true,
+      "under19Guarded": true,
+      "paymentProcessorSchema": "epoch.quote-payment",
+      "payloadMode": "provider-neutral-payment-json-preview",
+      "payloadSource": "epoch.quote-payment",
+      "payloadEntryCount": 2,
+      "readinessChecks": ["provider-candidate-required", "payment-provider-handoff-required", "quote-payment-schema-stable", "legal-review-required", "tax-review-required", "privacy-boundary-required", "under19-eligibility-gate", "sandbox-only-before-go-live", "operator-approval-required", "no-live-payment", "no-secrets", "no-oauth-client", "no-webhooks", "no-provider-writes", "no-checkout-session", "no-payment-capture", "no-refunds", "no-invoice-send", "no-customer-visible-payment-request"],
+      "payloadPreview": [
+        {
+          "uid": "epoch-payment-preview-eiken-monthly",
+          "title": "Premium EIKEN Writing Review payment preview",
+          "provider": "provider-neutral",
+          "amountJpy": 45000,
+          "currency": "JPY",
+          "customerName": "Adult writing student",
+          "packageId": "pkg-eiken-writing-monthly",
+          "source": "opportunity:opp-001",
+          "status": "preview-only",
+          "paymentStatus": "not-created",
+          "checkoutSession": "not-created",
+          "customerSafe": true
+        },
+        {
+          "uid": "epoch-payment-preview-under19-gate",
+          "title": "Under-19 compatibility assessment blocked payment preview",
+          "provider": "provider-neutral",
+          "amountJpy": 65000,
+          "currency": "JPY",
+          "customerName": "Under-19 compatibility review",
+          "packageId": "pkg-under19-assessment",
+          "source": "package:pkg-under19-assessment",
+          "status": "blocked-preview-only",
+          "paymentStatus": "guardian-consent-required",
+          "checkoutSession": "not-created",
+          "customerSafe": true
+        }
+      ],
+      "blockers": ["No legal/tax/privacy review signoff", "No checkout credential storage", "No webhook signing secret", "No live payment capture or refund path", "Under-19 payment requests remain blocked before guardian consent"],
+      "nextActionAt": "2026-06-04T12:00:00+09:00",
+      "createdAt": "2026-06-02T07:00:00+09:00",
+      "updatedAt": "2026-06-02T07:00:00+09:00",
+      "receiptIds": ["receipt-payment-provider-prototype-seed"],
+      "notes": "Local payment payload preview only; live checkout, invoice sending, capture, refunds, OAuth, secrets, webhooks, provider writes, and customer-visible payment requests remain disabled."
+    }
+  ],
   "paymentProviderHandoffs": [
     {
       "id": "payment-provider-invoice-readiness",
@@ -2184,6 +2261,21 @@ window.EPOCH_SEED_DATA = {
       "customerVisible": false
     },
     {
+      "id": "monitor-check-seed-payment-prototype",
+      "actionId": "seed-payment-provider-prototype",
+      "receiptId": "receipt-payment-provider-prototype-seed",
+      "title": "Sandbox payment provider prototype",
+      "summary": "EPOCH has a local payment payload preview for provider-neutral invoice/checkout readiness without live checkout, invoice sending, capture, refunds, credentials, webhooks, or customer-visible payment requests.",
+      "status": "complete",
+      "priority": "medium",
+      "effect": "payment-provider-sandbox-proof",
+      "target": "monitor-payment-prototype",
+      "owner": "Jack",
+      "createdAt": "2026-06-02T07:00:00+09:00",
+      "visibility": "internal",
+      "customerVisible": false
+    },
+    {
       "id": "monitor-check-seed-auth-session-role",
       "actionId": "seed-auth-session-role-baseline",
       "receiptId": "receipt-auth-session-role-seed",
@@ -2307,6 +2399,14 @@ window.EPOCH_SEED_DATA = {
       "status": "complete",
       "createdAt": "2026-06-02T00:24:00+09:00",
       "note": "Payment provider baseline: invoice, checkout, and guardian eligibility handoffs are provider-neutral and no-live-payment."
+    },
+    {
+      "id": "receipt-payment-provider-prototype-seed",
+      "customerId": null,
+      "kind": "payment-provider-prototype",
+      "status": "complete",
+      "createdAt": "2026-06-02T07:00:00+09:00",
+      "note": "Sandbox payment provider prototype baseline: local payment payload preview is ready; live checkout, invoice sending, capture, refunds, OAuth, secrets, webhooks, provider writes, and customer-visible payment requests remain disabled."
     },
     {
       "id": "receipt-auth-session-role-seed",

--- a/web/styles.css
+++ b/web/styles.css
@@ -767,7 +767,9 @@ button.secondary-action {
 .auth-session-role-console,
 .marketing-conversion-console,
 .provider-adapter-console,
-.calendar-adapter-console {
+.calendar-adapter-console,
+.notification-prototype-console,
+.payment-prototype-console {
   grid-template-columns: 1fr;
 }
 


### PR DESCRIPTION
## Summary

- Adds sandbox-only `paymentProviderPrototypes` records, defaults, creation/transition helpers, receipts, monitor timeline/risk/summary visibility, and operating-ledger export/import preservation.
- Adds the EPOCH monitor UI section and control form for local payment payload previews while keeping live checkout, invoice sending, capture, refunds, OAuth, secrets, webhooks, provider writes, and customer-visible payment requests disabled.
- Documents the sandbox payment provider prototype contract and extends the commercial-slice verifier to cover seed records, monitor summary, UI IDs, docs, ledger export/import, and disabled live-payment posture.

## Verification

- `npm run verify`
- `git diff --check` (only existing CRLF normalization warnings)
- Browser proof at `http://127.0.0.1:5173/index.html`: opened Monitor, navigated to Sandbox Payment Provider / Pay Proof, applied the sandbox payment provider action, confirmed sandbox-approved messaging, and verified browser console warnings/errors were empty.

Closes #72
