### PR TITLE
[codex] Add EPOCH calendar provider readiness gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ EPOCH owns:
 - customer-safe schedule status
 - submission/review deadlines when another product needs timing state
 - EPOCH MONITOR operational health, receipts, timeline, and control status
+- calendar-provider readiness gates that remain sandbox-only until explicit
+  later approval
 
 EPOCH does not own service packages, pricing, revenue operations, offer funnels,
 education delivery, consulting/support pipelines, CRM, or income-stream
@@ -37,10 +39,12 @@ the operational control and verification surface.
   schedule/operating primitives.
 - `native/epoch_core_smoke.c`: native smoke test for the core contract.
 - `web/shared/epoch-data.js`: schedule-focused demo data for app and webportal
-  rendering.
+  rendering plus the local EPOCH operating ledger.
 - `web/shared/surface.js`: shared app/webportal renderer and local request
   interaction.
 - `web/shared/styles.css`: EPOCH-specific surface styling.
+- `docs/calendar-provider-go-live-readiness-gate.md`: calendar-only provider
+  readiness gate contract for issue #78.
 - `tools/verify-commercial-slice.mjs`: repository verifier for EPOCH product
   boundary and surface placement.
 

--- a/docs/calendar-provider-go-live-readiness-gate.md
+++ b/docs/calendar-provider-go-live-readiness-gate.md
@@ -1,0 +1,85 @@
+# Calendar Provider Go-Live Readiness Gate
+
+## Purpose
+
+EPOCH may prepare calendar, availability, reminder, and schedule-status provider
+readiness locally before any live provider integration exists. This gate keeps
+provider work inside EPOCH's scheduling boundary and prevents live provider
+calls until a later explicit approval.
+
+## Scope
+
+This gate covers only EPOCH-owned time records:
+
+- schedule entries
+- schedule requests
+- availability windows
+- reminder rules
+- recurrence/deadline readiness
+- customer-safe timing statuses
+- revised-calendar mapping readiness
+
+WORKSHOP service delivery, packages, submissions, CRM, revenue, pricing,
+payments, authentication, analytics, ads, and customer acquisition are out of
+scope for this gate.
+
+## Required Readiness Checks
+
+`EpochCalendarProviderReadinessGate` is not ready for a live toggle until all
+of these are true:
+
+- sandbox prototype passed
+- local schedule records verified
+- customer-safe timing status verified
+- revised-calendar mapping verified
+- explicit operator approval recorded
+- live provider calls are still disabled before the toggle
+
+The web surfaces represent this as sandbox-only status. They do not call Google
+Calendar, Microsoft Graph, CalDAV, notification services, payment providers, or
+analytics providers.
+
+## Native Contract
+
+The native core now includes:
+
+- `EpochScheduleRequest`
+- `EpochAvailabilityWindow`
+- `EpochReminderRule`
+- `EpochCalendarProviderReadinessGate`
+- `epoch_schedule_request_is_customer_safe`
+- `epoch_availability_window_has_capacity`
+- `epoch_reminder_rule_is_sandbox_safe`
+- `epoch_calendar_provider_gate_ready_for_live_toggle`
+- `epoch_calendar_provider_gate_blocks_live_calls`
+
+## Web Contract
+
+The App and Webportal consume local ledger records through
+`EPOCH_LEDGER_KEY`.
+
+The App shows:
+
+- local schedule ledger counts
+- schedule queue
+- availability and deadline records
+- sandbox reminder rules
+- calendar-provider readiness gates
+- no-live-provider proof checks
+- local receipts
+
+The Webportal shows:
+
+- schedule request intake
+- customer-safe request status
+- availability windows
+- external calendar connection status
+
+The Webportal must never expose raw provider controls or MONITOR controls.
+
+## Go-Live Rule
+
+This issue does not approve live provider integrations. A later issue must
+explicitly approve provider credentials, OAuth or service-account posture,
+webhook behavior, external writes, invitation/send policy, rollback behavior,
+and customer notification wording before live calls are enabled.

--- a/native/epoch_core.c
+++ b/native/epoch_core.c
@@ -7,6 +7,11 @@ typedef struct EpochStatusName {
     const char *label;
 } EpochStatusName;
 
+typedef struct EpochProviderKindName {
+    EpochProviderKind kind;
+    const char *label;
+} EpochProviderKindName;
+
 static const EpochStatusName EPOCH_STATUS_NAMES[] = {
     {EPOCH_STATUS_PLANNED, "planned"},
     {EPOCH_STATUS_WAITING, "waiting"},
@@ -37,6 +42,13 @@ static const EpochStatusName EPOCH_STATUS_NAMES[] = {
     {EPOCH_STATUS_ROLLED_BACK, "rolled-back"},
     {EPOCH_STATUS_CANCELED, "canceled"},
     {EPOCH_STATUS_COMPLETE, "complete"},
+};
+
+static const EpochProviderKindName EPOCH_PROVIDER_KIND_NAMES[] = {
+    {EPOCH_PROVIDER_CALENDAR, "calendar"},
+    {EPOCH_PROVIDER_AVAILABILITY, "availability"},
+    {EPOCH_PROVIDER_REMINDER, "reminder"},
+    {EPOCH_PROVIDER_STATUS, "status"},
 };
 
 const char *epoch_status_label(EpochOperatingStatus status) {
@@ -100,4 +112,82 @@ int epoch_operating_entry_needs_attention(const EpochOperatingEntry *entry) {
            entry->status == EPOCH_STATUS_SUBMITTED ||
            entry->status == EPOCH_STATUS_REVIEWING ||
            entry->status == EPOCH_STATUS_IN_PROGRESS;
+}
+
+const char *epoch_provider_kind_label(EpochProviderKind kind) {
+    size_t i;
+
+    for (i = 0; i < sizeof(EPOCH_PROVIDER_KIND_NAMES) / sizeof(EPOCH_PROVIDER_KIND_NAMES[0]); i++) {
+        if (EPOCH_PROVIDER_KIND_NAMES[i].kind == kind) {
+            return EPOCH_PROVIDER_KIND_NAMES[i].label;
+        }
+    }
+
+    return "unknown";
+}
+
+int epoch_schedule_request_is_customer_safe(const EpochScheduleRequest *request) {
+    if (request == 0) {
+        return 0;
+    }
+
+    return request->customer_visible &&
+           request->sandbox_only &&
+           !request->provider_go_live_requested &&
+           request->customer_safe_status != 0 &&
+           request->customer_safe_status[0] != '\0' &&
+           request->status != EPOCH_STATUS_BLOCKED &&
+           request->status != EPOCH_STATUS_FAILED;
+}
+
+int epoch_availability_window_has_capacity(const EpochAvailabilityWindow *window) {
+    if (window == 0 || window->capacity <= 0 || window->holds < 0) {
+        return 0;
+    }
+
+    return window->holds < window->capacity &&
+           window->status == EPOCH_STATUS_AVAILABLE;
+}
+
+int epoch_reminder_rule_is_sandbox_safe(const EpochReminderRule *rule) {
+    if (rule == 0) {
+        return 0;
+    }
+
+    return rule->sandbox_only &&
+           rule->customer_safe_label != 0 &&
+           rule->customer_safe_label[0] != '\0' &&
+           rule->status != EPOCH_STATUS_FAILED;
+}
+
+static int epoch_calendar_provider_gate_prerequisites_passed(const EpochCalendarProviderReadinessGate *gate) {
+    if (gate == 0) {
+        return 0;
+    }
+
+    return gate->sandbox_prototype_passed &&
+           gate->local_records_verified &&
+           gate->customer_safe_status_verified &&
+           gate->revised_calendar_mapping_verified &&
+           gate->operator_approval_recorded &&
+           gate->status != EPOCH_STATUS_BLOCKED &&
+           gate->status != EPOCH_STATUS_FAILED;
+}
+
+int epoch_calendar_provider_gate_ready_for_live_toggle(const EpochCalendarProviderReadinessGate *gate) {
+    if (gate == 0) {
+        return 0;
+    }
+
+    return epoch_calendar_provider_gate_prerequisites_passed(gate) &&
+           !gate->live_provider_calls_enabled;
+}
+
+int epoch_calendar_provider_gate_blocks_live_calls(const EpochCalendarProviderReadinessGate *gate) {
+    if (gate == 0) {
+        return 1;
+    }
+
+    return !epoch_calendar_provider_gate_prerequisites_passed(gate) ||
+           !gate->live_provider_calls_enabled;
 }

--- a/native/epoch_core.h
+++ b/native/epoch_core.h
@@ -50,6 +50,13 @@ typedef enum EpochOperatingType {
     EPOCH_TYPE_RECEIPT
 } EpochOperatingType;
 
+typedef enum EpochProviderKind {
+    EPOCH_PROVIDER_CALENDAR = 0,
+    EPOCH_PROVIDER_AVAILABILITY,
+    EPOCH_PROVIDER_REMINDER,
+    EPOCH_PROVIDER_STATUS
+} EpochProviderKind;
+
 typedef struct EpochScheduleEntry {
     const char *id;
     const char *title;
@@ -59,6 +66,52 @@ typedef struct EpochScheduleEntry {
     const char *timezone;
     EpochOperatingStatus status;
 } EpochScheduleEntry;
+
+typedef struct EpochScheduleRequest {
+    const char *id;
+    const char *requester;
+    const char *requested_window;
+    const char *timezone;
+    const char *customer_safe_status;
+    EpochOperatingStatus status;
+    int customer_visible;
+    int sandbox_only;
+    int provider_go_live_requested;
+} EpochScheduleRequest;
+
+typedef struct EpochAvailabilityWindow {
+    const char *id;
+    const char *label;
+    const char *start_iso;
+    const char *end_iso;
+    const char *timezone;
+    int capacity;
+    int holds;
+    EpochOperatingStatus status;
+} EpochAvailabilityWindow;
+
+typedef struct EpochReminderRule {
+    const char *id;
+    const char *schedule_entry_id;
+    const char *rrule;
+    const char *customer_safe_label;
+    EpochOperatingStatus status;
+    int sandbox_only;
+    int customer_visible;
+} EpochReminderRule;
+
+typedef struct EpochCalendarProviderReadinessGate {
+    const char *id;
+    EpochProviderKind provider_kind;
+    EpochOperatingStatus status;
+    int sandbox_prototype_passed;
+    int local_records_verified;
+    int customer_safe_status_verified;
+    int revised_calendar_mapping_verified;
+    int operator_approval_recorded;
+    int live_provider_calls_enabled;
+    const char *blocker;
+} EpochCalendarProviderReadinessGate;
 
 typedef struct EpochOperatingEntry {
     const char *id;
@@ -75,6 +128,12 @@ const char *epoch_status_label(EpochOperatingStatus status);
 int epoch_status_from_label(const char *label, EpochOperatingStatus *out_status);
 int epoch_status_is_terminal(EpochOperatingStatus status);
 int epoch_operating_entry_needs_attention(const EpochOperatingEntry *entry);
+const char *epoch_provider_kind_label(EpochProviderKind kind);
+int epoch_schedule_request_is_customer_safe(const EpochScheduleRequest *request);
+int epoch_availability_window_has_capacity(const EpochAvailabilityWindow *window);
+int epoch_reminder_rule_is_sandbox_safe(const EpochReminderRule *rule);
+int epoch_calendar_provider_gate_ready_for_live_toggle(const EpochCalendarProviderReadinessGate *gate);
+int epoch_calendar_provider_gate_blocks_live_calls(const EpochCalendarProviderReadinessGate *gate);
 
 #ifdef __cplusplus
 }

--- a/native/epoch_core_smoke.c
+++ b/native/epoch_core_smoke.c
@@ -15,6 +15,48 @@ int main(void) {
         "2026-06-01T09:00:00+09:00",
         "2026-06-01T12:00:00+09:00",
     };
+    EpochScheduleRequest request = {
+        "req-001",
+        "schedule client",
+        "2026-06-04T18:00:00+09:00/2026-06-04T19:00:00+09:00",
+        "Asia/Tokyo",
+        "Request received; availability is being checked.",
+        EPOCH_STATUS_QUEUED,
+        1,
+        1,
+        0,
+    };
+    EpochAvailabilityWindow window = {
+        "win-001",
+        "Evening review block",
+        "2026-06-04T18:00:00+09:00",
+        "2026-06-04T21:00:00+09:00",
+        "Asia/Tokyo",
+        3,
+        1,
+        EPOCH_STATUS_AVAILABLE,
+    };
+    EpochReminderRule reminder = {
+        "rem-001",
+        "EPOCH-SCH-001",
+        "FREQ=DAILY;COUNT=2",
+        "Reminder preview only.",
+        EPOCH_STATUS_PLANNED,
+        1,
+        0,
+    };
+    EpochCalendarProviderReadinessGate gate = {
+        "gate-001",
+        EPOCH_PROVIDER_CALENDAR,
+        EPOCH_STATUS_REVIEWING,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        "",
+    };
 
     assert(strcmp(epoch_status_label(EPOCH_STATUS_SUBMITTED), "submitted") == 0);
     assert(strcmp(epoch_status_label(EPOCH_STATUS_PROPOSED), "proposed") == 0);
@@ -38,6 +80,16 @@ int main(void) {
     assert(epoch_status_is_terminal(EPOCH_STATUS_REJECTED) == 1);
     assert(epoch_status_is_terminal(EPOCH_STATUS_REVIEWING) == 0);
     assert(epoch_operating_entry_needs_attention(&overdue) == 1);
+    assert(strcmp(epoch_provider_kind_label(EPOCH_PROVIDER_CALENDAR), "calendar") == 0);
+    assert(strcmp(epoch_provider_kind_label(EPOCH_PROVIDER_STATUS), "status") == 0);
+    assert(epoch_schedule_request_is_customer_safe(&request) == 1);
+    assert(epoch_availability_window_has_capacity(&window) == 1);
+    assert(epoch_reminder_rule_is_sandbox_safe(&reminder) == 1);
+    assert(epoch_calendar_provider_gate_ready_for_live_toggle(&gate) == 1);
+    assert(epoch_calendar_provider_gate_blocks_live_calls(&gate) == 1);
+    gate.live_provider_calls_enabled = 1;
+    assert(epoch_calendar_provider_gate_ready_for_live_toggle(&gate) == 0);
+    assert(epoch_calendar_provider_gate_blocks_live_calls(&gate) == 0);
 
     return 0;
 }

--- a/tools/verify-commercial-slice.mjs
+++ b/tools/verify-commercial-slice.mjs
@@ -18,8 +18,16 @@ const styles = read("../web/shared/styles.css");
 const boundary = read("../docs/product-boundary.md");
 const runtime = read("../docs/runtime-and-packaging.md");
 const monitor = read("../docs/monitor-parity-health-controls.md");
+const providerGate = read("../docs/calendar-provider-go-live-readiness-gate.md");
 const header = read("../native/epoch_core.h");
 const source = read("../native/epoch_core.c");
+const {
+  createScheduleEntryForRequest,
+  createScheduleRequestRecord,
+  initialEpochLedger,
+  providerGateBlocksLiveCalls,
+  providerGateReadyForToggle
+} = await import("../web/shared/epoch-data.js");
 
 for (const phrase of ["EPOCH App", "EPOCH Webportal", "EPOCH MONITOR"]) {
   if (!root.includes(phrase)) fail(`root missing surface phrase ${phrase}`);
@@ -43,6 +51,9 @@ for (const phrase of [
   "Calendar Board",
   "Open Windows",
   "Schedule-Bound Work",
+  "Local Schedule Ledger",
+  "Calendar Provider Readiness",
+  "No-Live Provider Proof",
   "Revised Calendar Preview",
   "Native C Core"
 ]) {
@@ -54,6 +65,9 @@ for (const phrase of [
   "Ask For A Time",
   "Customer-Safe Timeline",
   "Next Open Windows",
+  "Provider Status",
+  "External Calendar Connection",
+  "Shows provider status without enabling live provider calls",
   "Does not expose raw admin or MONITOR controls"
 ]) {
   if (!portal.includes(phrase)) fail(`EPOCH webportal missing ${phrase}`);
@@ -69,7 +83,36 @@ for (const path of [
 
 for (const phrase of ["epochSchedule", "availabilityWindows", "deadlineItems", "revisedMonths", "portalTimeline"]) {
   if (!data.includes(phrase)) fail(`EPOCH data missing ${phrase}`);
-  if (!script.includes(phrase)) fail(`EPOCH renderer missing ${phrase}`);
+}
+
+for (const phrase of [
+  "EPOCH_LEDGER_KEY",
+  "initialEpochLedger",
+  "scheduleEntries",
+  "scheduleRequests",
+  "reminderRules",
+  "providerReadinessGates",
+  "providerStatusEvents",
+  "createScheduleRequestRecord",
+  "createScheduleEntryForRequest",
+  "providerGateReadyForToggle",
+  "providerGateBlocksLiveCalls"
+]) {
+  if (!data.includes(phrase)) fail(`EPOCH data missing ledger phrase ${phrase}`);
+}
+
+for (const phrase of [
+  "localStorage",
+  "EPOCH_LEDGER_KEY",
+  "schedule-request-form",
+  "schedule-need-select",
+  "customer-status-list",
+  "provider-readiness-list",
+  "portal-provider-status",
+  "provider-check-list",
+  "reset-schedule-ledger"
+]) {
+  if (!script.includes(phrase) && !app.includes(phrase) && !portal.includes(phrase)) fail(`EPOCH workflow missing ${phrase}`);
 }
 
 for (const status of [
@@ -92,10 +135,33 @@ for (const phrase of [
   "WORKSHOP owns revenue streams",
   "Native C is the default implementation language",
   "Avalonia is the desktop application shell",
-  "Compatibility aliases may redirect"
+  "Compatibility aliases may redirect",
+  "This issue does not approve live provider integrations"
 ]) {
-  const combined = `${boundary}\n${runtime}\n${monitor}`;
+  const combined = `${boundary}\n${runtime}\n${monitor}\n${providerGate}`;
   if (!combined.includes(phrase)) fail(`docs missing ${phrase}`);
+}
+
+for (const type of [
+  "EpochScheduleRequest",
+  "EpochAvailabilityWindow",
+  "EpochReminderRule",
+  "EpochCalendarProviderReadinessGate",
+  "EpochProviderKind"
+]) {
+  if (!header.includes(type)) fail(`native header missing contract ${type}`);
+}
+
+for (const fn of [
+  "epoch_provider_kind_label",
+  "epoch_schedule_request_is_customer_safe",
+  "epoch_availability_window_has_capacity",
+  "epoch_reminder_rule_is_sandbox_safe",
+  "epoch_calendar_provider_gate_ready_for_live_toggle",
+  "epoch_calendar_provider_gate_blocks_live_calls"
+]) {
+  if (!header.includes(fn)) fail(`native header missing function ${fn}`);
+  if (!source.includes(fn)) fail(`native source missing function ${fn}`);
 }
 
 for (const forbidden of [
@@ -114,8 +180,31 @@ for (const forbidden of [
   if (combinedWeb.includes(forbidden)) fail(`EPOCH web surface still contains WORKSHOP-only phrase ${forbidden}`);
 }
 
-for (const selector of [".directory-layout", ".workspace-grid", ".portal-grid", ".calendar-board", ".month-grid"]) {
+for (const selector of [".directory-layout", ".workspace-grid", ".portal-grid", ".calendar-board", ".month-grid", ".wide-panel", ".secondary-button"]) {
   if (!styles.includes(selector)) fail(`styles missing ${selector}`);
 }
+
+const fakeForm = new Map([
+  ["requester", "  "],
+  ["need", "submission-review-return"],
+  ["window", "Weekday evening Japan time"],
+  ["timezone", "Asia/Tokyo"]
+]);
+const request = createScheduleRequestRecord(fakeForm);
+const entry = createScheduleEntryForRequest(request);
+const gate = {
+  ...initialEpochLedger.providerReadinessGates[0],
+  revisedCalendarMappingVerified: true,
+  operatorApprovalRecorded: true,
+  liveProviderCallsEnabled: false
+};
+
+if (request.requester !== "Schedule requester") fail("schedule request factory did not default blank requester");
+if (request.providerGoLiveRequested !== false || request.sandboxOnly !== true) fail("schedule request factory is not sandbox-only");
+if (!entry.title.includes("Submission review return")) fail("schedule entry factory did not map need label");
+if (!providerGateReadyForToggle(gate)) fail("provider gate should be ready for live toggle after all checks");
+if (!providerGateBlocksLiveCalls(gate)) fail("provider gate should still block live calls before toggle");
+gate.liveProviderCallsEnabled = true;
+if (providerGateBlocksLiveCalls(gate)) fail("provider gate should allow live calls after explicit toggle and checks");
 
 console.log("EPOCH surface boundary verification passed");

--- a/web/app/index.html
+++ b/web/app/index.html
@@ -21,6 +21,20 @@
   </header>
 
   <main class="workspace-grid">
+    <section class="panel status-panel">
+      <div class="section-title">
+        <p class="eyebrow">Operating State</p>
+        <h2>Local Schedule Ledger</h2>
+      </div>
+      <dl class="status-grid">
+        <div><dt>Requests</dt><dd id="stat-schedule-requests">0</dd></div>
+        <div><dt>Open Windows</dt><dd id="stat-open-windows">0</dd></div>
+        <div><dt>Blocked Gates</dt><dd id="stat-provider-blocks">0</dd></div>
+        <div><dt>Provider State</dt><dd id="stat-live-state">Sandbox only</dd></div>
+      </dl>
+      <button id="reset-schedule-ledger" class="secondary-button" type="button">Reset Local Ledger</button>
+    </section>
+
     <section class="panel command-panel">
       <div class="section-title">
         <p class="eyebrow">Today</p>
@@ -55,10 +69,42 @@
 
     <section class="panel">
       <div class="section-title">
+        <p class="eyebrow">Reminders</p>
+        <h2>Sandbox Reminder Rules</h2>
+      </div>
+      <div id="reminder-rule-list" class="item-stack compact-list"></div>
+    </section>
+
+    <section class="panel wide-panel">
+      <div class="section-title">
+        <p class="eyebrow">Provider Gate</p>
+        <h2>Calendar Provider Readiness</h2>
+      </div>
+      <div id="provider-readiness-list" class="item-stack"></div>
+    </section>
+
+    <section class="panel">
+      <div class="section-title">
+        <p class="eyebrow">Gate Checks</p>
+        <h2>No-Live Provider Proof</h2>
+      </div>
+      <div id="provider-check-list" class="item-stack compact-list"></div>
+    </section>
+
+    <section class="panel">
+      <div class="section-title">
         <p class="eyebrow">13-Month Contract</p>
         <h2>Revised Calendar Preview</h2>
       </div>
       <div id="revised-calendar" class="month-grid"></div>
+    </section>
+
+    <section class="panel wide-panel">
+      <div class="section-title">
+        <p class="eyebrow">Receipts</p>
+        <h2>Local Schedule Evidence</h2>
+      </div>
+      <div id="receipt-list" class="item-stack compact-list"></div>
     </section>
 
     <section class="panel status-panel">

--- a/web/index.html
+++ b/web/index.html
@@ -25,7 +25,7 @@
         <p class="eyebrow">Internal Product</p>
         <h2>EPOCH App</h2>
       </div>
-      <p>Operator-facing schedule command: calendar board, availability windows, reminders, deadline queue, recurrence candidates, and local monitor handoff.</p>
+      <p>Operator-facing schedule command: calendar board, availability windows, reminders, deadline queue, recurrence candidates, provider-readiness gates, and local monitor handoff.</p>
       <div class="route-preview calendar-preview" aria-hidden="true">
         <span class="slot slot-a"></span>
         <span class="slot slot-b"></span>
@@ -40,7 +40,7 @@
         <p class="eyebrow">Customer Surface</p>
         <h2>EPOCH Webportal</h2>
       </div>
-      <p>Customer-safe scheduling portal: request timing, view deadlines, confirm availability, and receive schedule-bound status without exposing internal control surfaces.</p>
+      <p>Customer-safe scheduling portal: request timing, view deadlines, confirm availability, see external-calendar connection status, and receive schedule-bound updates without exposing internal control surfaces.</p>
       <div class="route-preview portal-preview" aria-hidden="true">
         <span></span><span></span><span></span>
       </div>

--- a/web/shared/epoch-data.js
+++ b/web/shared/epoch-data.js
@@ -1,49 +1,249 @@
-export const epochSchedule = [
-  {
-    id: "EPOCH-SCH-001",
-    title: "Submission review return window",
-    owner: "EPOCH",
-    status: "queued",
-    time: "2026-06-03 19:00 JST",
-    detail: "Schedule-bound return window requested by a WORKSHOP timing client."
-  },
-  {
-    id: "EPOCH-SCH-002",
-    title: "Calendar provider adapter review",
-    owner: "EPOCH",
-    status: "planned",
-    time: "2026-06-04 10:30 JST",
-    detail: "Internal provider-readiness check; no live provider write."
-  },
-  {
-    id: "EPOCH-SCH-003",
-    title: "Revised calendar contract pass",
-    owner: "EPOCH",
-    status: "in-progress",
-    time: "2026-06-05 14:00 JST",
-    detail: "Validate month mapping and schedule conversion rules."
-  }
+export const EPOCH_LEDGER_KEY = "epoch.operatingLedger.v1";
+
+export const scheduleNeedOptions = [
+  { value: "diagnostic-call", label: "Diagnostic call", entryType: "request" },
+  { value: "submission-review-return", label: "Submission review return", entryType: "review-deadline" },
+  { value: "project-planning-session", label: "Project planning session", entryType: "request" },
+  { value: "deadline-check-in", label: "Deadline check-in", entryType: "follow-up" },
+  { value: "reminder-only", label: "Reminder only", entryType: "reminder" }
 ];
 
-export const availabilityWindows = [
-  { label: "Evening review block", time: "Mon-Wed 19:00-21:00 JST", capacity: "2 holds" },
-  { label: "Admin scheduling block", time: "Fri 09:00-11:00 JST", capacity: "4 requests" },
-  { label: "Async deadline pass", time: "Sun 16:00-18:00 JST", capacity: "3 checks" }
-];
-
-export const deadlineItems = [
-  { label: "Customer schedule confirmation", due: "2026-06-03 12:00 JST", state: "waiting" },
-  { label: "Reminder recurrence review", due: "2026-06-05 17:00 JST", state: "planned" },
-  { label: "Calendar export handoff", due: "2026-06-07 09:00 JST", state: "blocked on adapter selection" }
-];
+export const initialEpochLedger = {
+  version: 1,
+  generatedAt: "2026-06-03T10:00:00+09:00",
+  scheduleEntries: [
+    {
+      id: "EPOCH-SCH-001",
+      title: "Submission review return window",
+      owner: "EPOCH",
+      status: "queued",
+      time: "2026-06-03 19:00 JST",
+      startIso: "2026-06-03T19:00:00+09:00",
+      endIso: "2026-06-03T20:00:00+09:00",
+      timezone: "Asia/Tokyo",
+      customerSafeStatus: "Return window is queued for operator review.",
+      detail: "Schedule-bound return window requested by a WORKSHOP timing client."
+    },
+    {
+      id: "EPOCH-SCH-002",
+      title: "Calendar provider readiness review",
+      owner: "EPOCH",
+      status: "planned",
+      time: "2026-06-04 10:30 JST",
+      startIso: "2026-06-04T10:30:00+09:00",
+      endIso: "2026-06-04T11:00:00+09:00",
+      timezone: "Asia/Tokyo",
+      customerSafeStatus: "Provider readiness is internal and sandbox-only.",
+      detail: "Internal provider-readiness gate; no live provider write."
+    },
+    {
+      id: "EPOCH-SCH-003",
+      title: "Revised calendar contract pass",
+      owner: "EPOCH",
+      status: "in-progress",
+      time: "2026-06-05 14:00 JST",
+      startIso: "2026-06-05T14:00:00+09:00",
+      endIso: "2026-06-05T15:00:00+09:00",
+      timezone: "Asia/Tokyo",
+      customerSafeStatus: "Revised-calendar mapping is being checked.",
+      detail: "Validate month mapping and schedule conversion rules."
+    }
+  ],
+  scheduleRequests: [
+    {
+      id: "EPOCH-REQ-001",
+      requester: "WORKSHOP timing handoff",
+      need: "submission-review-return",
+      requestedWindow: "2026-06-03 evening JST",
+      timezone: "Asia/Tokyo",
+      status: "queued",
+      sandboxOnly: true,
+      providerGoLiveRequested: false,
+      customerSafeStatus: "Timing request received; availability is being checked.",
+      createdAt: "2026-06-03T10:00:00+09:00"
+    }
+  ],
+  availabilityWindows: [
+    {
+      id: "EPOCH-WIN-001",
+      label: "Evening review block",
+      time: "Mon-Wed 19:00-21:00 JST",
+      startIso: "2026-06-03T19:00:00+09:00",
+      endIso: "2026-06-03T21:00:00+09:00",
+      timezone: "Asia/Tokyo",
+      capacity: 2,
+      holds: 1,
+      status: "available"
+    },
+    {
+      id: "EPOCH-WIN-002",
+      label: "Admin scheduling block",
+      time: "Fri 09:00-11:00 JST",
+      startIso: "2026-06-05T09:00:00+09:00",
+      endIso: "2026-06-05T11:00:00+09:00",
+      timezone: "Asia/Tokyo",
+      capacity: 4,
+      holds: 0,
+      status: "available"
+    },
+    {
+      id: "EPOCH-WIN-003",
+      label: "Async deadline pass",
+      time: "Sun 16:00-18:00 JST",
+      startIso: "2026-06-07T16:00:00+09:00",
+      endIso: "2026-06-07T18:00:00+09:00",
+      timezone: "Asia/Tokyo",
+      capacity: 3,
+      holds: 2,
+      status: "available"
+    }
+  ],
+  deadlineItems: [
+    { id: "EPOCH-DUE-001", label: "Customer schedule confirmation", due: "2026-06-03 12:00 JST", state: "waiting" },
+    { id: "EPOCH-DUE-002", label: "Reminder recurrence review", due: "2026-06-05 17:00 JST", state: "planned" },
+    { id: "EPOCH-DUE-003", label: "Calendar export handoff", due: "2026-06-07 09:00 JST", state: "blocked on adapter selection" }
+  ],
+  reminderRules: [
+    {
+      id: "EPOCH-REM-001",
+      scheduleEntryId: "EPOCH-SCH-001",
+      label: "Review return reminder preview",
+      rrule: "FREQ=DAILY;COUNT=2",
+      status: "planned",
+      sandboxOnly: true,
+      customerVisible: false,
+      customerSafeLabel: "Reminder preview is not sending."
+    },
+    {
+      id: "EPOCH-REM-002",
+      scheduleEntryId: "EPOCH-SCH-003",
+      label: "Revised calendar check reminder",
+      rrule: "FREQ=WEEKLY;COUNT=1",
+      status: "queued",
+      sandboxOnly: true,
+      customerVisible: false,
+      customerSafeLabel: "Internal reminder preview only."
+    }
+  ],
+  providerReadinessGates: [
+    {
+      id: "EPOCH-GATE-CALENDAR-001",
+      providerKind: "calendar",
+      targetProvider: "Provider-neutral calendar adapter",
+      status: "reviewing",
+      sandboxPrototypePassed: true,
+      localRecordsVerified: true,
+      customerSafeStatusVerified: true,
+      revisedCalendarMappingVerified: false,
+      operatorApprovalRecorded: false,
+      liveProviderCallsEnabled: false,
+      blocker: "Revised-calendar mapping and operator approval still required.",
+      customerSafeStatus: "External calendar connection is not active."
+    },
+    {
+      id: "EPOCH-GATE-AVAILABILITY-001",
+      providerKind: "availability",
+      targetProvider: "Availability export preview",
+      status: "planned",
+      sandboxPrototypePassed: true,
+      localRecordsVerified: true,
+      customerSafeStatusVerified: true,
+      revisedCalendarMappingVerified: true,
+      operatorApprovalRecorded: false,
+      liveProviderCallsEnabled: false,
+      blocker: "Operator approval required before any live toggle.",
+      customerSafeStatus: "Availability is shown from local EPOCH records."
+    }
+  ],
+  providerStatusEvents: [
+    { id: "EPOCH-PROVIDER-STATUS-001", label: "Sandbox calendar preview", state: "passed", detail: "Local payload preview exists; live write remains blocked." },
+    { id: "EPOCH-PROVIDER-STATUS-002", label: "Customer-safe status check", state: "passed", detail: "Portal text does not expose internal provider controls." },
+    { id: "EPOCH-PROVIDER-STATUS-003", label: "Operator approval", state: "waiting", detail: "No live provider toggle until an explicit later approval." }
+  ],
+  portalTimeline: [
+    { label: "Request received", detail: "Timing request is accepted into EPOCH scheduling.", state: "complete" },
+    { label: "Availability check", detail: "Operator reviews matching windows.", state: "in-progress" },
+    { label: "Provider status", detail: "External calendar connection remains inactive.", state: "sandbox-only" },
+    { label: "Confirmation pending", detail: "Customer-safe confirmation will be sent after approval.", state: "queued" }
+  ],
+  receipts: [
+    { id: "EPOCH-RECEIPT-GATE-001", status: "ready", summary: "Provider readiness gate blocks live calendar calls until sandbox, local records, customer-safe status, revised mapping, and operator approval are satisfied." },
+    { id: "EPOCH-RECEIPT-LEDGER-001", status: "ready", summary: "Local ledger contains schedule entries, requests, availability windows, reminder rules, and provider-readiness gates." }
+  ]
+};
 
 export const revisedMonths = [
   "Aster", "Beryl", "Crown", "Dawn", "Ember", "Frost", "Grove",
   "Harbor", "Ivory", "Juniper", "Keystone", "Lumen", "Meridian"
 ];
 
-export const portalTimeline = [
-  { label: "Request received", detail: "Timing request is accepted into EPOCH scheduling.", state: "complete" },
-  { label: "Availability check", detail: "Operator reviews matching windows.", state: "in-progress" },
-  { label: "Confirmation pending", detail: "Customer-safe confirmation will be sent after approval.", state: "queued" }
-];
+export const epochSchedule = initialEpochLedger.scheduleEntries;
+export const availabilityWindows = initialEpochLedger.availabilityWindows.map((window) => ({
+  ...window,
+  capacity: `${window.capacity - window.holds} open of ${window.capacity}`
+}));
+export const deadlineItems = initialEpochLedger.deadlineItems;
+export const portalTimeline = initialEpochLedger.portalTimeline;
+
+export function makeId(prefix) {
+  const random = Math.random().toString(36).slice(2, 8);
+  return `${prefix}-${Date.now().toString(36)}-${random}`;
+}
+
+export function scheduleNeedLabel(value) {
+  return scheduleNeedOptions.find((need) => need.value === value)?.label || value;
+}
+
+function providerGatePrerequisitesPassed(gate) {
+  return Boolean(
+    gate?.sandboxPrototypePassed &&
+    gate?.localRecordsVerified &&
+    gate?.customerSafeStatusVerified &&
+    gate?.revisedCalendarMappingVerified &&
+    gate?.operatorApprovalRecorded &&
+    !["blocked", "failed"].includes(gate?.status)
+  );
+}
+
+export function providerGateReadyForToggle(gate) {
+  return providerGatePrerequisitesPassed(gate) && !gate?.liveProviderCallsEnabled;
+}
+
+export function providerGateBlocksLiveCalls(gate) {
+  return !providerGatePrerequisitesPassed(gate) || !gate?.liveProviderCallsEnabled;
+}
+
+export function createScheduleRequestRecord(form) {
+  const requester = String(form.get("requester") || "").trim() || "Schedule requester";
+  const need = String(form.get("need") || "diagnostic-call");
+  const requestedWindow = String(form.get("window") || "").trim() || "Window to be confirmed";
+  const timezone = String(form.get("timezone") || "").trim() || "Asia/Tokyo";
+  const createdAt = new Date().toISOString();
+  return {
+    id: makeId("EPOCH-REQ"),
+    requester,
+    need,
+    requestedWindow,
+    timezone,
+    status: "queued",
+    sandboxOnly: true,
+    providerGoLiveRequested: false,
+    customerSafeStatus: "Schedule request received; availability is being checked.",
+    createdAt
+  };
+}
+
+export function createScheduleEntryForRequest(request) {
+  return {
+    id: makeId("EPOCH-SCH"),
+    title: scheduleNeedLabel(request.need),
+    owner: "EPOCH",
+    status: "queued",
+    time: request.requestedWindow,
+    startIso: "",
+    endIso: "",
+    timezone: request.timezone,
+    customerSafeStatus: request.customerSafeStatus,
+    detail: `${request.requester} requested ${scheduleNeedLabel(request.need)}.`
+  };
+}

--- a/web/shared/styles.css
+++ b/web/shared/styles.css
@@ -148,6 +148,13 @@ button {
   color: var(--ink);
 }
 
+.secondary-button {
+  width: 100%;
+  margin-top: 14px;
+  background: #fff;
+  color: var(--ink);
+}
+
 .directory-layout,
 .workspace-grid,
 .portal-grid {
@@ -173,6 +180,10 @@ button {
 .panel {
   padding: 20px;
   box-shadow: var(--shadow);
+}
+
+.wide-panel {
+  grid-column: span 2;
 }
 
 .primary-surface {
@@ -257,6 +268,11 @@ button {
   padding: 14px;
   border: 1px solid var(--line);
   background: #fbfcf8;
+}
+
+.empty-state {
+  margin: 0;
+  color: var(--muted);
 }
 
 .item-card {
@@ -411,6 +427,10 @@ select {
 
   .month-grid {
     grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .wide-panel {
+    grid-column: auto;
   }
 }
 

--- a/web/shared/surface.js
+++ b/web/shared/surface.js
@@ -1,107 +1,300 @@
-import { availabilityWindows, deadlineItems, epochSchedule, portalTimeline, revisedMonths } from "./epoch-data.js";
+import {
+  EPOCH_LEDGER_KEY,
+  createScheduleEntryForRequest,
+  createScheduleRequestRecord,
+  initialEpochLedger,
+  providerGateBlocksLiveCalls,
+  providerGateReadyForToggle,
+  revisedMonths,
+  scheduleNeedLabel,
+  scheduleNeedOptions
+} from "./epoch-data.js";
 
-const renderStack = (targetId, items, renderItem) => {
-  const target = document.getElementById(targetId);
-  if (!target) return;
-  target.innerHTML = items.map(renderItem).join("");
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const escapeHtml = (value) => String(value ?? "")
+  .replaceAll("&", "&amp;")
+  .replaceAll("<", "&lt;")
+  .replaceAll(">", "&gt;")
+  .replaceAll('"', "&quot;")
+  .replaceAll("'", "&#039;");
+
+const getStorage = () => {
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
 };
 
-const chip = (value) => `<span class="state-chip">${value}</span>`;
+const mergeLedger = (stored) => {
+  const base = clone(initialEpochLedger);
+  if (!stored || typeof stored !== "object") return base;
+  for (const key of [
+    "scheduleEntries",
+    "scheduleRequests",
+    "availabilityWindows",
+    "deadlineItems",
+    "reminderRules",
+    "providerReadinessGates",
+    "providerStatusEvents",
+    "portalTimeline",
+    "receipts"
+  ]) {
+    if (Array.isArray(stored[key])) base[key] = stored[key];
+  }
+  base.version = stored.version || base.version;
+  base.generatedAt = stored.generatedAt || base.generatedAt;
+  return base;
+};
 
-renderStack("schedule-queue", epochSchedule, (item) => `
-  <article class="item-card">
-    <div>
-      <strong>${item.title}</strong>
-      <p>${item.detail}</p>
-    </div>
-    <div class="item-meta">
-      ${chip(item.status)}
-      <span>${item.time}</span>
-    </div>
-  </article>
-`);
+const loadLedger = () => {
+  const storage = getStorage();
+  if (!storage) return clone(initialEpochLedger);
+  try {
+    return mergeLedger(JSON.parse(storage.getItem(EPOCH_LEDGER_KEY)));
+  } catch {
+    return clone(initialEpochLedger);
+  }
+};
 
-renderStack("availability-list", availabilityWindows, (item) => `
-  <article class="mini-row">
-    <strong>${item.label}</strong>
-    <span>${item.time}</span>
-    <small>${item.capacity}</small>
-  </article>
-`);
+const saveLedger = (nextLedger) => {
+  const storage = getStorage();
+  if (storage) storage.setItem(EPOCH_LEDGER_KEY, JSON.stringify(nextLedger));
+};
 
-renderStack("deadline-list", deadlineItems, (item) => `
-  <article class="mini-row">
-    <strong>${item.label}</strong>
-    <span>${item.due}</span>
-    <small>${item.state}</small>
-  </article>
-`);
+const state = {
+  ledger: loadLedger()
+};
 
-renderStack("portal-availability", availabilityWindows, (item) => `
-  <article class="mini-row">
-    <strong>${item.label}</strong>
-    <span>${item.time}</span>
-    <small>${item.capacity}</small>
-  </article>
-`);
+const byId = (id) => document.getElementById(id);
 
-renderStack("portal-timeline", portalTimeline, (item) => `
-  <article class="item-card">
-    <div>
-      <strong>${item.label}</strong>
-      <p>${item.detail}</p>
-    </div>
-    ${chip(item.state)}
-  </article>
-`);
+const chip = (value) => `<span class="state-chip">${escapeHtml(value)}</span>`;
 
-const board = document.getElementById("calendar-board");
-if (board) {
-  board.innerHTML = epochSchedule.map((item, index) => `
-    <article class="calendar-event event-${index + 1}">
-      <span>${item.time}</span>
-      <strong>${item.title}</strong>
-      <small>${item.status}</small>
+const renderStack = (targetId, items, renderItem, emptyText = "No records yet.") => {
+  const target = byId(targetId);
+  if (!target) return;
+  target.innerHTML = items.length
+    ? items.map(renderItem).join("")
+    : `<p class="empty-state">${escapeHtml(emptyText)}</p>`;
+};
+
+const setText = (id, value) => {
+  const target = byId(id);
+  if (target) target.textContent = value;
+};
+
+const renderNeedOptions = () => {
+  const target = byId("schedule-need-select");
+  if (!target) return;
+  target.innerHTML = scheduleNeedOptions.map((option) => `
+    <option value="${escapeHtml(option.value)}">${escapeHtml(option.label)}</option>
+  `).join("");
+};
+
+function renderStats() {
+  const gates = state.ledger.providerReadinessGates;
+  const blockedGateCount = gates.filter((gate) => providerGateBlocksLiveCalls(gate)).length;
+  const openWindowCount = state.ledger.availabilityWindows.filter((window) => window.holds < window.capacity).length;
+  setText("stat-schedule-requests", String(state.ledger.scheduleRequests.length));
+  setText("stat-open-windows", String(openWindowCount));
+  setText("stat-provider-blocks", String(blockedGateCount));
+  setText("stat-live-state", gates.some((gate) => gate.liveProviderCallsEnabled) ? "Live enabled" : "Sandbox only");
+}
+
+function renderScheduleQueue() {
+  renderStack("schedule-queue", state.ledger.scheduleEntries, (item) => `
+    <article class="item-card">
+      <div>
+        <strong>${escapeHtml(item.title)}</strong>
+        <p>${escapeHtml(item.detail)}</p>
+        <small>${escapeHtml(item.customerSafeStatus)}</small>
+      </div>
+      <div class="item-meta">
+        ${chip(item.status)}
+        <span>${escapeHtml(item.time)}</span>
+      </div>
+    </article>
+  `);
+}
+
+function renderCalendarBoard() {
+  const board = byId("calendar-board");
+  if (!board) return;
+  board.innerHTML = state.ledger.scheduleEntries.map((item, index) => `
+    <article class="calendar-event event-${(index % 3) + 1}">
+      <span>${escapeHtml(item.time)}</span>
+      <strong>${escapeHtml(item.title)}</strong>
+      <small>${escapeHtml(item.status)}</small>
     </article>
   `).join("");
 }
 
-const monthGrid = document.getElementById("revised-calendar");
-if (monthGrid) {
+function renderAvailability() {
+  const renderWindow = (item) => `
+    <article class="mini-row">
+      <strong>${escapeHtml(item.label)}</strong>
+      <span>${escapeHtml(item.time)}</span>
+      <small>${escapeHtml(item.capacity - item.holds)} open of ${escapeHtml(item.capacity)} · ${escapeHtml(item.status)}</small>
+    </article>
+  `;
+  renderStack("availability-list", state.ledger.availabilityWindows, renderWindow);
+  renderStack("portal-availability", state.ledger.availabilityWindows, renderWindow);
+}
+
+function renderDeadlinesAndReminders() {
+  renderStack("deadline-list", state.ledger.deadlineItems, (item) => `
+    <article class="mini-row">
+      <strong>${escapeHtml(item.label)}</strong>
+      <span>${escapeHtml(item.due)}</span>
+      <small>${escapeHtml(item.state)}</small>
+    </article>
+  `);
+
+  renderStack("reminder-rule-list", state.ledger.reminderRules, (item) => `
+    <article class="mini-row">
+      <strong>${escapeHtml(item.label)}</strong>
+      <span>${escapeHtml(item.rrule)}</span>
+      <small>${escapeHtml(item.customerSafeLabel)} · ${item.sandboxOnly ? "sandbox-only" : "review required"}</small>
+    </article>
+  `);
+}
+
+function renderRevisedCalendar() {
+  const monthGrid = byId("revised-calendar");
+  if (!monthGrid) return;
   monthGrid.innerHTML = revisedMonths.map((month, index) => `
     <span>
       <strong>${String(index + 1).padStart(2, "0")}</strong>
-      ${month}
+      ${escapeHtml(month)}
     </span>
   `).join("");
 }
 
-const requestForm = document.getElementById("schedule-request-form");
-if (requestForm) {
-  requestForm.addEventListener("submit", (event) => {
-    event.preventDefault();
-    const form = new FormData(requestForm);
-    const requester = form.get("requester");
-    const need = form.get("need");
-    const confirmation = document.getElementById("request-confirmation");
-    const timeline = document.getElementById("portal-timeline");
-    const entry = {
-      label: "New request queued",
-      detail: `${requester} requested: ${need}.`,
-      state: "queued"
-    };
-    portalTimeline.unshift(entry);
-    if (confirmation) confirmation.textContent = "Schedule request added locally for EPOCH operator review.";
-    if (timeline) {
-      timeline.innerHTML = portalTimeline.map((item) => `
-        <article class="item-card">
-          <div>
-            <strong>${item.label}</strong>
-            <p>${item.detail}</p>
-          </div>
-          ${chip(item.state)}
-        </article>
-      `).join("");
-    }
+function renderProviderReadiness() {
+  const renderGate = (gate) => {
+    const ready = providerGateReadyForToggle(gate);
+    const blocked = providerGateBlocksLiveCalls(gate);
+    return `
+      <article class="item-card">
+        <div>
+          <strong>${escapeHtml(gate.targetProvider)}</strong>
+          <p>${escapeHtml(gate.customerSafeStatus)}</p>
+          <small>${escapeHtml(gate.blocker || "No blocker recorded.")}</small>
+        </div>
+        <div class="item-meta">
+          ${chip(ready ? "ready for approval" : gate.status)}
+          <span>${blocked ? "live calls blocked" : "live calls allowed"}</span>
+        </div>
+      </article>
+    `;
+  };
+
+  renderStack("provider-readiness-list", state.ledger.providerReadinessGates, renderGate);
+  renderStack("portal-provider-status", state.ledger.providerReadinessGates, (gate) => `
+    <article class="mini-row">
+      <strong>${escapeHtml(gate.targetProvider)}</strong>
+      <span>${providerGateBlocksLiveCalls(gate) ? "inactive" : "active"}</span>
+      <small>${escapeHtml(gate.customerSafeStatus)}</small>
+    </article>
+  `);
+
+  renderStack("provider-check-list", state.ledger.providerStatusEvents, (item) => `
+    <article class="mini-row">
+      <strong>${escapeHtml(item.label)}</strong>
+      <span>${escapeHtml(item.state)}</span>
+      <small>${escapeHtml(item.detail)}</small>
+    </article>
+  `);
+}
+
+function renderPortalTimeline() {
+  renderStack("portal-timeline", state.ledger.portalTimeline, (item) => `
+    <article class="item-card">
+      <div>
+        <strong>${escapeHtml(item.label)}</strong>
+        <p>${escapeHtml(item.detail)}</p>
+      </div>
+      ${chip(item.state)}
+    </article>
+  `);
+
+  renderStack("customer-status-list", state.ledger.scheduleRequests.slice(0, 5), (item) => `
+    <article class="mini-row">
+      <strong>${escapeHtml(item.requester)}</strong>
+      <span>${escapeHtml(item.status)}</span>
+      <small>${escapeHtml(item.customerSafeStatus)}</small>
+    </article>
+  `);
+}
+
+function renderReceipts() {
+  renderStack("receipt-list", state.ledger.receipts, (item) => `
+    <article class="mini-row">
+      <strong>${escapeHtml(item.id)}</strong>
+      <span>${escapeHtml(item.status)}</span>
+      <small>${escapeHtml(item.summary)}</small>
+    </article>
+  `);
+}
+
+function appendReceipt(summary, status = "ready") {
+  state.ledger.receipts.unshift({
+    id: `EPOCH-RECEIPT-${Date.now().toString(36)}`,
+    status,
+    summary
   });
 }
+
+function addTimeline(label, detail, timelineState = "queued") {
+  state.ledger.portalTimeline.unshift({ label, detail, state: timelineState });
+}
+
+function renderAll() {
+  renderNeedOptions();
+  renderStats();
+  renderScheduleQueue();
+  renderCalendarBoard();
+  renderAvailability();
+  renderDeadlinesAndReminders();
+  renderRevisedCalendar();
+  renderProviderReadiness();
+  renderPortalTimeline();
+  renderReceipts();
+}
+
+function handleScheduleRequest(event) {
+  event.preventDefault();
+  const form = event.currentTarget;
+  const data = new FormData(form);
+  const request = createScheduleRequestRecord(data);
+  const entry = createScheduleEntryForRequest(request);
+
+  state.ledger.scheduleRequests.unshift(request);
+  state.ledger.scheduleEntries.unshift(entry);
+  addTimeline("New request queued", `${request.requester} requested ${scheduleNeedLabel(request.need)}.`, request.status);
+  appendReceipt(`${request.requester} added a local-only schedule request.`);
+  saveLedger(state.ledger);
+
+  const confirmation = byId("request-confirmation");
+  if (confirmation) confirmation.textContent = request.customerSafeStatus;
+  form.reset();
+  renderAll();
+}
+
+function bindControls() {
+  const requestForm = byId("schedule-request-form");
+  if (requestForm) requestForm.addEventListener("submit", handleScheduleRequest);
+
+  const resetButton = byId("reset-schedule-ledger");
+  if (resetButton) {
+    resetButton.addEventListener("click", () => {
+      state.ledger = clone(initialEpochLedger);
+      saveLedger(state.ledger);
+      renderAll();
+    });
+  }
+}
+
+renderAll();
+bindControls();

--- a/web/webportal/index.html
+++ b/web/webportal/index.html
@@ -29,24 +29,19 @@
       <form id="schedule-request-form" class="surface-form">
         <label>
           Name
-          <input name="requester" value="Sample Customer" required />
+          <input id="requester" name="requester" value="Sample Customer" required />
         </label>
         <label>
           Schedule need
-          <select name="need">
-            <option>Diagnostic call</option>
-            <option>Submission review return</option>
-            <option>Project planning session</option>
-            <option>Deadline check-in</option>
-          </select>
+          <select id="schedule-need-select" name="need"></select>
         </label>
         <label>
           Preferred window
-          <input name="window" value="Weekday evening Japan time" required />
+          <input id="requested-window" name="window" value="Weekday evening Japan time" required />
         </label>
         <label>
           Timezone
-          <input name="timezone" value="Asia/Tokyo" required />
+          <input id="timezone" name="timezone" value="Asia/Tokyo" required />
         </label>
         <button type="submit">Add Schedule Request</button>
       </form>
@@ -63,10 +58,26 @@
 
     <section class="panel">
       <div class="section-title">
+        <p class="eyebrow">Requests</p>
+        <h2>Schedule Status</h2>
+      </div>
+      <div id="customer-status-list" class="item-stack compact-list"></div>
+    </section>
+
+    <section class="panel">
+      <div class="section-title">
         <p class="eyebrow">Availability</p>
         <h2>Next Open Windows</h2>
       </div>
       <div id="portal-availability" class="item-stack compact-list"></div>
+    </section>
+
+    <section class="panel">
+      <div class="section-title">
+        <p class="eyebrow">Provider Status</p>
+        <h2>External Calendar Connection</h2>
+      </div>
+      <div id="portal-provider-status" class="item-stack compact-list"></div>
     </section>
 
     <section class="panel">
@@ -77,6 +88,7 @@
       <ul class="boundary-list">
         <li>Accepts schedule and deadline requests.</li>
         <li>Shows customer-safe timing updates.</li>
+        <li>Shows provider status without enabling live provider calls.</li>
         <li>Does not sell packages or run delivery work.</li>
         <li>Does not expose raw admin or MONITOR controls.</li>
       </ul>


### PR DESCRIPTION
﻿## Summary

Implements EPOCH issue #78 as a narrowed calendar/scheduling provider-readiness gate.

- resets the old blended provider WIP to clean EPOCH `main` and replaces it with an EPOCH-only gate
- adds native C contracts for schedule requests, availability windows, reminder rules, and calendar-provider readiness gates
- adds local-first EPOCH operating ledger state for schedule entries, requests, availability, reminders, provider gates, customer-safe status, and receipts
- updates EPOCH App and Webportal to render provider readiness/status without enabling live provider calls
- expands verifier coverage with runtime factory/gate assertions
- documents the go-live rule: this issue does not approve live provider integrations

## Boundary

This PR intentionally excludes WORKSHOP service delivery, packages, CRM, revenue, submissions, payments, auth, analytics, notifications, ads, credentials, OAuth, webhooks, external writes, and live provider calls.

## Validation

- `npm run verify`
- `cmake --build build; ctest --test-dir build -C Debug --output-on-failure`
- Browser-checked EPOCH Webportal request creation and persistence into EPOCH App
- Browser-checked EPOCH App provider readiness, no-live proof, and no revenue bleed
- Browser-checked live EPOCH MONITOR provider-gate operating state on `127.0.0.1:8765`
- Browser-regression-checked WORKSHOP MONITOR after shared product monitor renderer generalization
- `python -m py_compile D:\CITADEL\_control\scripts\hermes_persona_monitor.py`

## Local Monitor Note

The live EPOCH MONITOR provider-gate display required a local generator patch in `D:\CITADEL\_control\scripts\hermes_persona_monitor.py`. `D:\CITADEL` is not a git repository, so that patch is not included in this EPOCH repository PR.

Advances #78.
