### PR TITLE
[codex] Add EPOCH native scheduling core

### DIFF
--- a/docs/reminder-recurrence-availability-contract.md
+++ b/docs/reminder-recurrence-availability-contract.md
@@ -17,6 +17,15 @@ invitations, syncing external calendars, or delivering automated reminders.
   approval before creating future sessions.
 - `availabilityWindows`: provider/operator availability and blocked windows for
   booking, cohort clustering, and capacity planning.
+- `deadlineItems`: deadline-health records that keep due-state visibility inside
+  EPOCH scheduling rather than in service-delivery or CRM records.
+
+## Native C guard
+
+`EpochRecurrenceRule` is sandbox-safe only when it is local-only, does not create
+future schedule entries, has a valid RRULE, and is not failed, blocked, or
+canceled. Revised-calendar recurrence additionally requires operator approval
+because the 13-month rulepack is not yet owner-approved.
 
 ## Visibility
 

--- a/docs/revised-13-month-calendar-contract.md
+++ b/docs/revised-13-month-calendar-contract.md
@@ -30,6 +30,20 @@ or approved:
 
 ## Native C contract
 
+Current native boundary records rulepack readiness before conversion logic is
+allowed. The first implementation uses:
+
+- `EpochCalendarSystem` to distinguish Gregorian and revised-calendar schedule
+  context.
+- `EpochRecurrenceRule` to keep recurrence previews sandboxed until an operator
+  approves the calendar context.
+- `EpochDeadlineRule` and `EpochDeadlineHealth` to keep deadline status
+  schedule-owned and customer-safe.
+- `EpochRevisedCalendarRulepack` to hold every owner-approved decision required
+  before revised-date conversion can run.
+- `epoch_revised_calendar_rulepack_blocks_conversion` as the guard for draft,
+  partial, or disabled rulepacks.
+
 Once approved, the native C core should own:
 
 - Gregorian to revised-date conversion

--- a/docs/v1-minimal-scheduling-surface.md
+++ b/docs/v1-minimal-scheduling-surface.md
@@ -30,6 +30,17 @@ schedule model, not EPOCH's revenue product scope.
 - end timestamp
 - timezone
 - status such as active or canceled
+- native validity through `EpochScheduleEntry` and
+  `epoch_schedule_entry_is_valid`
+
+### Scheduling guard records
+
+- `EpochScheduleRequest` for customer-safe schedule requests
+- `EpochAvailabilityWindow` for local capacity checks
+- `EpochReminderRule` for sandbox-only reminder previews
+- `EpochRecurrenceRule` for preview-only recurrence candidates
+- `EpochDeadlineRule` for schedule-owned deadline health
+- `EpochRevisedCalendarRulepack` for the owner-approved 13-month calendar gate
 
 ### Operating entry
 

--- a/native/epoch_core.c
+++ b/native/epoch_core.c
@@ -12,6 +12,16 @@ typedef struct EpochProviderKindName {
     const char *label;
 } EpochProviderKindName;
 
+typedef struct EpochCalendarSystemName {
+    EpochCalendarSystem system;
+    const char *label;
+} EpochCalendarSystemName;
+
+typedef struct EpochDeadlineHealthName {
+    EpochDeadlineHealth health;
+    const char *label;
+} EpochDeadlineHealthName;
+
 static const EpochStatusName EPOCH_STATUS_NAMES[] = {
     {EPOCH_STATUS_PLANNED, "planned"},
     {EPOCH_STATUS_WAITING, "waiting"},
@@ -50,6 +60,22 @@ static const EpochProviderKindName EPOCH_PROVIDER_KIND_NAMES[] = {
     {EPOCH_PROVIDER_REMINDER, "reminder"},
     {EPOCH_PROVIDER_STATUS, "status"},
 };
+
+static const EpochCalendarSystemName EPOCH_CALENDAR_SYSTEM_NAMES[] = {
+    {EPOCH_CALENDAR_GREGORIAN, "gregorian"},
+    {EPOCH_CALENDAR_REVISED_13_MONTH, "revised-13-month"},
+};
+
+static const EpochDeadlineHealthName EPOCH_DEADLINE_HEALTH_NAMES[] = {
+    {EPOCH_DEADLINE_ON_TRACK, "on-track"},
+    {EPOCH_DEADLINE_AT_RISK, "at-risk"},
+    {EPOCH_DEADLINE_OVERDUE, "overdue"},
+    {EPOCH_DEADLINE_BLOCKED, "blocked"},
+};
+
+static int epoch_text_present(const char *value) {
+    return value != 0 && value[0] != '\0';
+}
 
 const char *epoch_status_label(EpochOperatingStatus status) {
     size_t i;
@@ -126,6 +152,46 @@ const char *epoch_provider_kind_label(EpochProviderKind kind) {
     return "unknown";
 }
 
+const char *epoch_calendar_system_label(EpochCalendarSystem system) {
+    size_t i;
+
+    for (i = 0; i < sizeof(EPOCH_CALENDAR_SYSTEM_NAMES) / sizeof(EPOCH_CALENDAR_SYSTEM_NAMES[0]); i++) {
+        if (EPOCH_CALENDAR_SYSTEM_NAMES[i].system == system) {
+            return EPOCH_CALENDAR_SYSTEM_NAMES[i].label;
+        }
+    }
+
+    return "unknown";
+}
+
+const char *epoch_deadline_health_label(EpochDeadlineHealth health) {
+    size_t i;
+
+    for (i = 0; i < sizeof(EPOCH_DEADLINE_HEALTH_NAMES) / sizeof(EPOCH_DEADLINE_HEALTH_NAMES[0]); i++) {
+        if (EPOCH_DEADLINE_HEALTH_NAMES[i].health == health) {
+            return EPOCH_DEADLINE_HEALTH_NAMES[i].label;
+        }
+    }
+
+    return "unknown";
+}
+
+int epoch_schedule_entry_is_valid(const EpochScheduleEntry *entry) {
+    if (entry == 0) {
+        return 0;
+    }
+
+    return epoch_text_present(entry->id) &&
+           epoch_text_present(entry->title) &&
+           epoch_text_present(entry->start_iso) &&
+           epoch_text_present(entry->end_iso) &&
+           epoch_text_present(entry->timezone) &&
+           entry->status != EPOCH_STATUS_FAILED &&
+           entry->status != EPOCH_STATUS_REJECTED &&
+           entry->status != EPOCH_STATUS_ROLLED_BACK &&
+           entry->status != EPOCH_STATUS_CANCELED;
+}
+
 int epoch_schedule_request_is_customer_safe(const EpochScheduleRequest *request) {
     if (request == 0) {
         return 0;
@@ -134,8 +200,7 @@ int epoch_schedule_request_is_customer_safe(const EpochScheduleRequest *request)
     return request->customer_visible &&
            request->sandbox_only &&
            !request->provider_go_live_requested &&
-           request->customer_safe_status != 0 &&
-           request->customer_safe_status[0] != '\0' &&
+           epoch_text_present(request->customer_safe_status) &&
            request->status != EPOCH_STATUS_BLOCKED &&
            request->status != EPOCH_STATUS_FAILED;
 }
@@ -155,9 +220,72 @@ int epoch_reminder_rule_is_sandbox_safe(const EpochReminderRule *rule) {
     }
 
     return rule->sandbox_only &&
-           rule->customer_safe_label != 0 &&
-           rule->customer_safe_label[0] != '\0' &&
+           epoch_text_present(rule->customer_safe_label) &&
            rule->status != EPOCH_STATUS_FAILED;
+}
+
+int epoch_recurrence_rule_is_sandbox_safe(const EpochRecurrenceRule *rule) {
+    if (rule == 0) {
+        return 0;
+    }
+
+    return rule->sandbox_only &&
+           !rule->creates_future_entries &&
+           epoch_text_present(rule->id) &&
+           epoch_text_present(rule->schedule_entry_id) &&
+           epoch_text_present(rule->rrule) &&
+           rule->status != EPOCH_STATUS_FAILED &&
+           rule->status != EPOCH_STATUS_BLOCKED &&
+           rule->status != EPOCH_STATUS_CANCELED &&
+           (rule->calendar_system != EPOCH_CALENDAR_REVISED_13_MONTH || rule->operator_approved);
+}
+
+int epoch_deadline_rule_is_customer_safe(const EpochDeadlineRule *rule) {
+    if (rule == 0) {
+        return 0;
+    }
+
+    return rule->customer_visible &&
+           epoch_text_present(rule->id) &&
+           epoch_text_present(rule->linked_entry_id) &&
+           epoch_text_present(rule->due_iso) &&
+           epoch_text_present(rule->timezone) &&
+           epoch_text_present(rule->customer_safe_status) &&
+           rule->status != EPOCH_STATUS_FAILED &&
+           rule->status != EPOCH_STATUS_BLOCKED &&
+           rule->health != EPOCH_DEADLINE_BLOCKED;
+}
+
+int epoch_revised_calendar_rulepack_has_required_approvals(const EpochRevisedCalendarRulepack *rulepack) {
+    if (rulepack == 0) {
+        return 0;
+    }
+
+    return epoch_text_present(rulepack->id) &&
+           epoch_text_present(rulepack->version_id) &&
+           rulepack->month_count == 13 &&
+           rulepack->month_names_approved &&
+           rulepack->day_distribution_approved &&
+           rulepack->intercalary_days_approved &&
+           rulepack->leap_rule_approved &&
+           rulepack->epoch_anchor_approved &&
+           rulepack->day_of_week_mapping_approved &&
+           rulepack->formatting_rules_approved &&
+           rulepack->timezone_boundary_approved &&
+           rulepack->recurrence_mapping_approved &&
+           rulepack->public_display_wording_approved &&
+           rulepack->storage_identifier_approved &&
+           rulepack->conversion_rules_approved &&
+           rulepack->owner_approved;
+}
+
+int epoch_revised_calendar_rulepack_conversion_ready(const EpochRevisedCalendarRulepack *rulepack) {
+    return epoch_revised_calendar_rulepack_has_required_approvals(rulepack) &&
+           rulepack->conversion_logic_enabled;
+}
+
+int epoch_revised_calendar_rulepack_blocks_conversion(const EpochRevisedCalendarRulepack *rulepack) {
+    return !epoch_revised_calendar_rulepack_conversion_ready(rulepack);
 }
 
 static int epoch_calendar_provider_gate_prerequisites_passed(const EpochCalendarProviderReadinessGate *gate) {

--- a/native/epoch_core.h
+++ b/native/epoch_core.h
@@ -57,6 +57,18 @@ typedef enum EpochProviderKind {
     EPOCH_PROVIDER_STATUS
 } EpochProviderKind;
 
+typedef enum EpochCalendarSystem {
+    EPOCH_CALENDAR_GREGORIAN = 0,
+    EPOCH_CALENDAR_REVISED_13_MONTH
+} EpochCalendarSystem;
+
+typedef enum EpochDeadlineHealth {
+    EPOCH_DEADLINE_ON_TRACK = 0,
+    EPOCH_DEADLINE_AT_RISK,
+    EPOCH_DEADLINE_OVERDUE,
+    EPOCH_DEADLINE_BLOCKED
+} EpochDeadlineHealth;
+
 typedef struct EpochScheduleEntry {
     const char *id;
     const char *title;
@@ -100,6 +112,48 @@ typedef struct EpochReminderRule {
     int customer_visible;
 } EpochReminderRule;
 
+typedef struct EpochRecurrenceRule {
+    const char *id;
+    const char *schedule_entry_id;
+    const char *rrule;
+    EpochCalendarSystem calendar_system;
+    EpochOperatingStatus status;
+    int sandbox_only;
+    int operator_approved;
+    int creates_future_entries;
+} EpochRecurrenceRule;
+
+typedef struct EpochDeadlineRule {
+    const char *id;
+    const char *linked_entry_id;
+    const char *due_iso;
+    const char *timezone;
+    const char *customer_safe_status;
+    EpochDeadlineHealth health;
+    EpochOperatingStatus status;
+    int customer_visible;
+} EpochDeadlineRule;
+
+typedef struct EpochRevisedCalendarRulepack {
+    const char *id;
+    const char *version_id;
+    int month_count;
+    int month_names_approved;
+    int day_distribution_approved;
+    int intercalary_days_approved;
+    int leap_rule_approved;
+    int epoch_anchor_approved;
+    int day_of_week_mapping_approved;
+    int formatting_rules_approved;
+    int timezone_boundary_approved;
+    int recurrence_mapping_approved;
+    int public_display_wording_approved;
+    int storage_identifier_approved;
+    int conversion_rules_approved;
+    int owner_approved;
+    int conversion_logic_enabled;
+} EpochRevisedCalendarRulepack;
+
 typedef struct EpochCalendarProviderReadinessGate {
     const char *id;
     EpochProviderKind provider_kind;
@@ -129,9 +183,17 @@ int epoch_status_from_label(const char *label, EpochOperatingStatus *out_status)
 int epoch_status_is_terminal(EpochOperatingStatus status);
 int epoch_operating_entry_needs_attention(const EpochOperatingEntry *entry);
 const char *epoch_provider_kind_label(EpochProviderKind kind);
+const char *epoch_calendar_system_label(EpochCalendarSystem system);
+const char *epoch_deadline_health_label(EpochDeadlineHealth health);
+int epoch_schedule_entry_is_valid(const EpochScheduleEntry *entry);
 int epoch_schedule_request_is_customer_safe(const EpochScheduleRequest *request);
 int epoch_availability_window_has_capacity(const EpochAvailabilityWindow *window);
 int epoch_reminder_rule_is_sandbox_safe(const EpochReminderRule *rule);
+int epoch_recurrence_rule_is_sandbox_safe(const EpochRecurrenceRule *rule);
+int epoch_deadline_rule_is_customer_safe(const EpochDeadlineRule *rule);
+int epoch_revised_calendar_rulepack_has_required_approvals(const EpochRevisedCalendarRulepack *rulepack);
+int epoch_revised_calendar_rulepack_conversion_ready(const EpochRevisedCalendarRulepack *rulepack);
+int epoch_revised_calendar_rulepack_blocks_conversion(const EpochRevisedCalendarRulepack *rulepack);
 int epoch_calendar_provider_gate_ready_for_live_toggle(const EpochCalendarProviderReadinessGate *gate);
 int epoch_calendar_provider_gate_blocks_live_calls(const EpochCalendarProviderReadinessGate *gate);
 

--- a/native/epoch_core_smoke.c
+++ b/native/epoch_core_smoke.c
@@ -26,6 +26,15 @@ int main(void) {
         1,
         0,
     };
+    EpochScheduleEntry schedule_entry = {
+        "sch-001",
+        "Gregorian schedule review",
+        "local-only schedule entry",
+        "2026-06-04T18:00:00+09:00",
+        "2026-06-04T19:00:00+09:00",
+        "Asia/Tokyo",
+        EPOCH_STATUS_QUEUED,
+    };
     EpochAvailabilityWindow window = {
         "win-001",
         "Evening review block",
@@ -44,6 +53,64 @@ int main(void) {
         EPOCH_STATUS_PLANNED,
         1,
         0,
+    };
+    EpochRecurrenceRule recurrence = {
+        "rec-001",
+        "EPOCH-SCH-001",
+        "FREQ=WEEKLY;COUNT=2",
+        EPOCH_CALENDAR_GREGORIAN,
+        EPOCH_STATUS_PLANNED,
+        1,
+        0,
+        0,
+    };
+    EpochDeadlineRule deadline = {
+        "due-001",
+        "EPOCH-SCH-001",
+        "2026-06-05T17:00:00+09:00",
+        "Asia/Tokyo",
+        "Deadline is on track.",
+        EPOCH_DEADLINE_ON_TRACK,
+        EPOCH_STATUS_PLANNED,
+        1,
+    };
+    EpochRevisedCalendarRulepack draft_rulepack = {
+        "rulepack-draft",
+        "owner-approved-rulepack-required",
+        13,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    };
+    EpochRevisedCalendarRulepack approved_rulepack = {
+        "rulepack-approved",
+        "owner-approved-rulepack-v1",
+        13,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
     };
     EpochCalendarProviderReadinessGate gate = {
         "gate-001",
@@ -82,9 +149,22 @@ int main(void) {
     assert(epoch_operating_entry_needs_attention(&overdue) == 1);
     assert(strcmp(epoch_provider_kind_label(EPOCH_PROVIDER_CALENDAR), "calendar") == 0);
     assert(strcmp(epoch_provider_kind_label(EPOCH_PROVIDER_STATUS), "status") == 0);
+    assert(strcmp(epoch_calendar_system_label(EPOCH_CALENDAR_REVISED_13_MONTH), "revised-13-month") == 0);
+    assert(strcmp(epoch_deadline_health_label(EPOCH_DEADLINE_AT_RISK), "at-risk") == 0);
+    assert(epoch_schedule_entry_is_valid(&schedule_entry) == 1);
     assert(epoch_schedule_request_is_customer_safe(&request) == 1);
     assert(epoch_availability_window_has_capacity(&window) == 1);
     assert(epoch_reminder_rule_is_sandbox_safe(&reminder) == 1);
+    assert(epoch_recurrence_rule_is_sandbox_safe(&recurrence) == 1);
+    assert(epoch_deadline_rule_is_customer_safe(&deadline) == 1);
+    assert(epoch_revised_calendar_rulepack_has_required_approvals(&draft_rulepack) == 0);
+    assert(epoch_revised_calendar_rulepack_conversion_ready(&draft_rulepack) == 0);
+    assert(epoch_revised_calendar_rulepack_blocks_conversion(&draft_rulepack) == 1);
+    assert(epoch_revised_calendar_rulepack_has_required_approvals(&approved_rulepack) == 1);
+    assert(epoch_revised_calendar_rulepack_conversion_ready(&approved_rulepack) == 1);
+    assert(epoch_revised_calendar_rulepack_blocks_conversion(&approved_rulepack) == 0);
+    approved_rulepack.conversion_logic_enabled = 0;
+    assert(epoch_revised_calendar_rulepack_conversion_ready(&approved_rulepack) == 0);
     assert(epoch_calendar_provider_gate_ready_for_live_toggle(&gate) == 1);
     assert(epoch_calendar_provider_gate_blocks_live_calls(&gate) == 1);
     gate.live_provider_calls_enabled = 1;

--- a/tools/verify-commercial-slice.mjs
+++ b/tools/verify-commercial-slice.mjs
@@ -26,7 +26,9 @@ const {
   createScheduleRequestRecord,
   initialEpochLedger,
   providerGateBlocksLiveCalls,
-  providerGateReadyForToggle
+  providerGateReadyForToggle,
+  revisedRulepackBlocksConversion,
+  revisedRulepackReady
 } = await import("../web/shared/epoch-data.js");
 
 for (const phrase of ["EPOCH App", "EPOCH Webportal", "EPOCH MONITOR"]) {
@@ -54,7 +56,10 @@ for (const phrase of [
   "Local Schedule Ledger",
   "Calendar Provider Readiness",
   "No-Live Provider Proof",
+  "Native Scheduling Core",
+  "Recurrence Candidates",
   "Revised Calendar Preview",
+  "Revised Rulepack Boundary",
   "Native C Core"
 ]) {
   if (!app.includes(phrase)) fail(`EPOCH app missing ${phrase}`);
@@ -66,6 +71,7 @@ for (const phrase of [
   "Customer-Safe Timeline",
   "Next Open Windows",
   "Provider Status",
+  "Revised Calendar Status",
   "External Calendar Connection",
   "Shows provider status without enabling live provider calls",
   "Does not expose raw admin or MONITOR controls"
@@ -90,13 +96,18 @@ for (const phrase of [
   "initialEpochLedger",
   "scheduleEntries",
   "scheduleRequests",
+  "schedulingCoreReadiness",
   "reminderRules",
+  "recurrenceCandidates",
+  "revisedCalendarRulepack",
   "providerReadinessGates",
   "providerStatusEvents",
   "createScheduleRequestRecord",
   "createScheduleEntryForRequest",
   "providerGateReadyForToggle",
-  "providerGateBlocksLiveCalls"
+  "providerGateBlocksLiveCalls",
+  "revisedRulepackReady",
+  "revisedRulepackBlocksConversion"
 ]) {
   if (!data.includes(phrase)) fail(`EPOCH data missing ledger phrase ${phrase}`);
 }
@@ -110,6 +121,10 @@ for (const phrase of [
   "provider-readiness-list",
   "portal-provider-status",
   "provider-check-list",
+  "native-core-readiness",
+  "recurrence-candidate-list",
+  "revised-rulepack-status",
+  "portal-revised-status",
   "reset-schedule-ledger"
 ]) {
   if (!script.includes(phrase) && !app.includes(phrase) && !portal.includes(phrase)) fail(`EPOCH workflow missing ${phrase}`);
@@ -146,6 +161,11 @@ for (const type of [
   "EpochScheduleRequest",
   "EpochAvailabilityWindow",
   "EpochReminderRule",
+  "EpochRecurrenceRule",
+  "EpochDeadlineRule",
+  "EpochRevisedCalendarRulepack",
+  "EpochCalendarSystem",
+  "EpochDeadlineHealth",
   "EpochCalendarProviderReadinessGate",
   "EpochProviderKind"
 ]) {
@@ -154,9 +174,16 @@ for (const type of [
 
 for (const fn of [
   "epoch_provider_kind_label",
+  "epoch_calendar_system_label",
+  "epoch_deadline_health_label",
+  "epoch_schedule_entry_is_valid",
   "epoch_schedule_request_is_customer_safe",
   "epoch_availability_window_has_capacity",
   "epoch_reminder_rule_is_sandbox_safe",
+  "epoch_recurrence_rule_is_sandbox_safe",
+  "epoch_deadline_rule_is_customer_safe",
+  "epoch_revised_calendar_rulepack_conversion_ready",
+  "epoch_revised_calendar_rulepack_blocks_conversion",
   "epoch_calendar_provider_gate_ready_for_live_toggle",
   "epoch_calendar_provider_gate_blocks_live_calls"
 ]) {
@@ -192,6 +219,25 @@ const fakeForm = new Map([
 ]);
 const request = createScheduleRequestRecord(fakeForm);
 const entry = createScheduleEntryForRequest(request);
+const rulepack = initialEpochLedger.revisedCalendarRulepack;
+const approvedRulepack = {
+  ...rulepack,
+  versionId: "owner-approved-rulepack-v1",
+  ownerApproved: true,
+  monthNamesApproved: true,
+  dayDistributionApproved: true,
+  intercalaryDaysApproved: true,
+  leapRuleApproved: true,
+  epochAnchorApproved: true,
+  dayOfWeekMappingApproved: true,
+  formattingRulesApproved: true,
+  timezoneBoundaryApproved: true,
+  recurrenceMappingApproved: true,
+  publicDisplayWordingApproved: true,
+  storageIdentifierApproved: true,
+  conversionRulesApproved: true,
+  conversionLogicEnabled: true
+};
 const gate = {
   ...initialEpochLedger.providerReadinessGates[0],
   revisedCalendarMappingVerified: true,
@@ -206,5 +252,10 @@ if (!providerGateReadyForToggle(gate)) fail("provider gate should be ready for l
 if (!providerGateBlocksLiveCalls(gate)) fail("provider gate should still block live calls before toggle");
 gate.liveProviderCallsEnabled = true;
 if (providerGateBlocksLiveCalls(gate)) fail("provider gate should allow live calls after explicit toggle and checks");
+if (revisedRulepackReady(rulepack)) fail("draft revised rulepack must not be conversion-ready");
+if (!revisedRulepackBlocksConversion(rulepack)) fail("draft revised rulepack must block conversion");
+if (!revisedRulepackReady(approvedRulepack)) fail("approved revised rulepack should be conversion-ready");
+approvedRulepack.conversionLogicEnabled = false;
+if (revisedRulepackReady(approvedRulepack)) fail("disabled conversion logic should keep approved rulepack held");
 
 console.log("EPOCH surface boundary verification passed");

--- a/web/app/index.html
+++ b/web/app/index.html
@@ -31,6 +31,8 @@
         <div><dt>Open Windows</dt><dd id="stat-open-windows">0</dd></div>
         <div><dt>Blocked Gates</dt><dd id="stat-provider-blocks">0</dd></div>
         <div><dt>Provider State</dt><dd id="stat-live-state">Sandbox only</dd></div>
+        <div><dt>Core State</dt><dd id="stat-core-state">pending</dd></div>
+        <div><dt>Rulepack</dt><dd id="stat-rulepack-state">held</dd></div>
       </dl>
       <button id="reset-schedule-ledger" class="secondary-button" type="button">Reset Local Ledger</button>
     </section>
@@ -75,6 +77,22 @@
       <div id="reminder-rule-list" class="item-stack compact-list"></div>
     </section>
 
+    <section class="panel">
+      <div class="section-title">
+        <p class="eyebrow">Recurrence</p>
+        <h2>Recurrence Candidates</h2>
+      </div>
+      <div id="recurrence-candidate-list" class="item-stack compact-list"></div>
+    </section>
+
+    <section class="panel wide-panel">
+      <div class="section-title">
+        <p class="eyebrow">Native Core</p>
+        <h2>Native Scheduling Core</h2>
+      </div>
+      <div id="native-core-readiness" class="item-stack compact-list readiness-grid"></div>
+    </section>
+
     <section class="panel wide-panel">
       <div class="section-title">
         <p class="eyebrow">Provider Gate</p>
@@ -97,6 +115,14 @@
         <h2>Revised Calendar Preview</h2>
       </div>
       <div id="revised-calendar" class="month-grid"></div>
+    </section>
+
+    <section class="panel wide-panel">
+      <div class="section-title">
+        <p class="eyebrow">13-Month Contract</p>
+        <h2>Revised Rulepack Boundary</h2>
+      </div>
+      <div id="revised-rulepack-status" class="item-stack"></div>
     </section>
 
     <section class="panel wide-panel">

--- a/web/shared/epoch-data.js
+++ b/web/shared/epoch-data.js
@@ -11,6 +11,53 @@ export const scheduleNeedOptions = [
 export const initialEpochLedger = {
   version: 1,
   generatedAt: "2026-06-03T10:00:00+09:00",
+  schedulingCoreReadiness: {
+    id: "EPOCH-CORE-SCHEDULING-001",
+    nativeContract: "epoch_core",
+    scheduleEntryValidation: "ready",
+    scheduleRequestValidation: "ready",
+    availabilityValidation: "ready",
+    deadlineHealthValidation: "ready",
+    recurrenceSandboxValidation: "ready",
+    customerSafeStatusValidation: "ready",
+    revisedRulepackGate: "conversion-held",
+    liveProviderPosture: "blocked"
+  },
+  revisedCalendarRulepack: {
+    id: "EPOCH-RULEPACK-DRAFT-001",
+    versionId: "owner-approved-rulepack-required",
+    calendarSystem: "revised-13-month",
+    monthCount: 13,
+    status: "draft-only",
+    ownerApproved: false,
+    monthNamesApproved: false,
+    dayDistributionApproved: false,
+    intercalaryDaysApproved: false,
+    leapRuleApproved: false,
+    epochAnchorApproved: false,
+    dayOfWeekMappingApproved: false,
+    formattingRulesApproved: false,
+    timezoneBoundaryApproved: false,
+    recurrenceMappingApproved: false,
+    publicDisplayWordingApproved: false,
+    storageIdentifierApproved: false,
+    conversionRulesApproved: false,
+    conversionLogicEnabled: false,
+    missingApprovals: [
+      "month names and display order",
+      "number of days in each month",
+      "extra or intercalary day treatment",
+      "leap rule",
+      "Gregorian anchor",
+      "day-of-week mapping",
+      "formatting and parsing",
+      "timezone boundary behavior",
+      "recurrence behavior",
+      "public display wording",
+      "storage representation"
+    ],
+    customerSafeStatus: "Revised calendar display is draft-only; schedule conversion waits for the owner-approved rulepack."
+  },
   scheduleEntries: [
     {
       id: "EPOCH-SCH-001",
@@ -99,9 +146,35 @@ export const initialEpochLedger = {
     }
   ],
   deadlineItems: [
-    { id: "EPOCH-DUE-001", label: "Customer schedule confirmation", due: "2026-06-03 12:00 JST", state: "waiting" },
-    { id: "EPOCH-DUE-002", label: "Reminder recurrence review", due: "2026-06-05 17:00 JST", state: "planned" },
-    { id: "EPOCH-DUE-003", label: "Calendar export handoff", due: "2026-06-07 09:00 JST", state: "blocked on adapter selection" }
+    { id: "EPOCH-DUE-001", label: "Customer schedule confirmation", due: "2026-06-03 12:00 JST", state: "waiting", health: "at-risk", customerSafeStatus: "Confirmation is waiting for operator review." },
+    { id: "EPOCH-DUE-002", label: "Reminder recurrence review", due: "2026-06-05 17:00 JST", state: "planned", health: "on-track", customerSafeStatus: "Reminder rule review is planned." },
+    { id: "EPOCH-DUE-003", label: "Calendar export handoff", due: "2026-06-07 09:00 JST", state: "blocked on adapter selection", health: "blocked", customerSafeStatus: "Calendar export is not active." }
+  ],
+  recurrenceCandidates: [
+    {
+      id: "EPOCH-REC-001",
+      scheduleEntryId: "EPOCH-SCH-001",
+      label: "Weekly return-window review",
+      rrule: "FREQ=WEEKLY;COUNT=4",
+      calendarSystem: "gregorian",
+      status: "planned",
+      sandboxOnly: true,
+      operatorApproved: false,
+      createsFutureEntries: false,
+      customerSafeStatus: "Repeat pattern is a local preview."
+    },
+    {
+      id: "EPOCH-REC-002",
+      scheduleEntryId: "EPOCH-SCH-003",
+      label: "Revised-calendar recurrence hold",
+      rrule: "FREQ=MONTHLY;COUNT=2",
+      calendarSystem: "revised-13-month",
+      status: "blocked",
+      sandboxOnly: true,
+      operatorApproved: false,
+      createsFutureEntries: false,
+      customerSafeStatus: "Revised-calendar recurrence waits for the owner-approved rulepack."
+    }
   ],
   reminderRules: [
     {
@@ -173,8 +246,10 @@ export const initialEpochLedger = {
 };
 
 export const revisedMonths = [
-  "Aster", "Beryl", "Crown", "Dawn", "Ember", "Frost", "Grove",
-  "Harbor", "Ivory", "Juniper", "Keystone", "Lumen", "Meridian"
+  "Draft Month 01", "Draft Month 02", "Draft Month 03", "Draft Month 04",
+  "Draft Month 05", "Draft Month 06", "Draft Month 07", "Draft Month 08",
+  "Draft Month 09", "Draft Month 10", "Draft Month 11", "Draft Month 12",
+  "Draft Month 13"
 ];
 
 export const epochSchedule = initialEpochLedger.scheduleEntries;
@@ -211,6 +286,35 @@ export function providerGateReadyForToggle(gate) {
 
 export function providerGateBlocksLiveCalls(gate) {
   return !providerGatePrerequisitesPassed(gate) || !gate?.liveProviderCallsEnabled;
+}
+
+export function revisedRulepackHasRequiredApprovals(rulepack) {
+  return Boolean(
+    rulepack?.id &&
+    rulepack?.versionId &&
+    rulepack?.monthCount === 13 &&
+    rulepack?.monthNamesApproved &&
+    rulepack?.dayDistributionApproved &&
+    rulepack?.intercalaryDaysApproved &&
+    rulepack?.leapRuleApproved &&
+    rulepack?.epochAnchorApproved &&
+    rulepack?.dayOfWeekMappingApproved &&
+    rulepack?.formattingRulesApproved &&
+    rulepack?.timezoneBoundaryApproved &&
+    rulepack?.recurrenceMappingApproved &&
+    rulepack?.publicDisplayWordingApproved &&
+    rulepack?.storageIdentifierApproved &&
+    rulepack?.conversionRulesApproved &&
+    rulepack?.ownerApproved
+  );
+}
+
+export function revisedRulepackReady(rulepack) {
+  return revisedRulepackHasRequiredApprovals(rulepack) && Boolean(rulepack?.conversionLogicEnabled);
+}
+
+export function revisedRulepackBlocksConversion(rulepack) {
+  return !revisedRulepackReady(rulepack);
 }
 
 export function createScheduleRequestRecord(form) {

--- a/web/shared/styles.css
+++ b/web/shared/styles.css
@@ -261,6 +261,10 @@ button {
   gap: 12px;
 }
 
+.readiness-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .item-card,
 .mini-row {
   display: grid;
@@ -448,6 +452,10 @@ select {
   }
 
   .item-card {
+    grid-template-columns: 1fr;
+  }
+
+  .readiness-grid {
     grid-template-columns: 1fr;
   }
 

--- a/web/shared/surface.js
+++ b/web/shared/surface.js
@@ -5,6 +5,8 @@ import {
   initialEpochLedger,
   providerGateBlocksLiveCalls,
   providerGateReadyForToggle,
+  revisedRulepackBlocksConversion,
+  revisedRulepackReady,
   revisedMonths,
   scheduleNeedLabel,
   scheduleNeedOptions
@@ -35,6 +37,7 @@ const mergeLedger = (stored) => {
     "scheduleRequests",
     "availabilityWindows",
     "deadlineItems",
+    "recurrenceCandidates",
     "reminderRules",
     "providerReadinessGates",
     "providerStatusEvents",
@@ -42,6 +45,12 @@ const mergeLedger = (stored) => {
     "receipts"
   ]) {
     if (Array.isArray(stored[key])) base[key] = stored[key];
+  }
+  if (stored.schedulingCoreReadiness && typeof stored.schedulingCoreReadiness === "object") {
+    base.schedulingCoreReadiness = stored.schedulingCoreReadiness;
+  }
+  if (stored.revisedCalendarRulepack && typeof stored.revisedCalendarRulepack === "object") {
+    base.revisedCalendarRulepack = stored.revisedCalendarRulepack;
   }
   base.version = stored.version || base.version;
   base.generatedAt = stored.generatedAt || base.generatedAt;
@@ -100,6 +109,8 @@ function renderStats() {
   setText("stat-open-windows", String(openWindowCount));
   setText("stat-provider-blocks", String(blockedGateCount));
   setText("stat-live-state", gates.some((gate) => gate.liveProviderCallsEnabled) ? "Live enabled" : "Sandbox only");
+  setText("stat-core-state", state.ledger.schedulingCoreReadiness?.scheduleEntryValidation || "pending");
+  setText("stat-rulepack-state", revisedRulepackReady(state.ledger.revisedCalendarRulepack) ? "ready" : "held");
 }
 
 function renderScheduleQueue() {
@@ -147,7 +158,15 @@ function renderDeadlinesAndReminders() {
     <article class="mini-row">
       <strong>${escapeHtml(item.label)}</strong>
       <span>${escapeHtml(item.due)}</span>
-      <small>${escapeHtml(item.state)}</small>
+      <small>${escapeHtml(item.health || "unscored")} - ${escapeHtml(item.customerSafeStatus || item.state)}</small>
+    </article>
+  `);
+
+  renderStack("recurrence-candidate-list", state.ledger.recurrenceCandidates || [], (item) => `
+    <article class="mini-row">
+      <strong>${escapeHtml(item.label)}</strong>
+      <span>${escapeHtml(item.rrule)} - ${escapeHtml(item.calendarSystem)}</span>
+      <small>${item.createsFutureEntries ? "future creation enabled" : "preview only"} - ${escapeHtml(item.customerSafeStatus)}</small>
     </article>
   `);
 
@@ -162,13 +181,60 @@ function renderDeadlinesAndReminders() {
 
 function renderRevisedCalendar() {
   const monthGrid = byId("revised-calendar");
-  if (!monthGrid) return;
-  monthGrid.innerHTML = revisedMonths.map((month, index) => `
-    <span>
-      <strong>${String(index + 1).padStart(2, "0")}</strong>
-      ${escapeHtml(month)}
-    </span>
-  `).join("");
+  if (monthGrid) {
+    monthGrid.innerHTML = revisedMonths.map((month, index) => `
+      <span>
+        <strong>${String(index + 1).padStart(2, "0")}</strong>
+        ${escapeHtml(month)}
+      </span>
+    `).join("");
+  }
+
+  const rulepack = state.ledger.revisedCalendarRulepack || {};
+  const blocked = revisedRulepackBlocksConversion(rulepack);
+  const missing = Array.isArray(rulepack.missingApprovals) ? rulepack.missingApprovals : [];
+  renderStack("revised-rulepack-status", [rulepack], (item) => `
+    <article class="item-card">
+      <div>
+        <strong>${escapeHtml(item.id || "rulepack")}</strong>
+        <p>${escapeHtml(item.customerSafeStatus || "Rulepack status unavailable.")}</p>
+        <small>${missing.slice(0, 5).map(escapeHtml).join(", ")}${missing.length > 5 ? "..." : ""}</small>
+      </div>
+      <div class="item-meta">
+        ${chip(blocked ? "conversion held" : "conversion ready")}
+        <span>${escapeHtml(item.versionId || "no version")}</span>
+      </div>
+    </article>
+  `);
+
+  renderStack("portal-revised-status", [rulepack], (item) => `
+    <article class="mini-row">
+      <strong>${escapeHtml(item.calendarSystem || "revised calendar")}</strong>
+      <span>${blocked ? "conversion inactive" : "conversion ready"}</span>
+      <small>${escapeHtml(item.customerSafeStatus || "")}</small>
+    </article>
+  `);
+}
+
+function renderCoreReadiness() {
+  const core = state.ledger.schedulingCoreReadiness || {};
+  const checks = [
+    ["Schedule Entry", core.scheduleEntryValidation],
+    ["Schedule Request", core.scheduleRequestValidation],
+    ["Availability", core.availabilityValidation],
+    ["Deadline Health", core.deadlineHealthValidation],
+    ["Recurrence", core.recurrenceSandboxValidation],
+    ["Customer Status", core.customerSafeStatusValidation],
+    ["Rulepack Gate", core.revisedRulepackGate],
+    ["Live Provider", core.liveProviderPosture]
+  ];
+  renderStack("native-core-readiness", checks, ([label, value]) => `
+    <article class="mini-row">
+      <strong>${escapeHtml(label)}</strong>
+      <span>${escapeHtml(value || "pending")}</span>
+      <small>${escapeHtml(core.nativeContract || "epoch_core")}</small>
+    </article>
+  `);
 }
 
 function renderProviderReadiness() {
@@ -257,6 +323,7 @@ function renderAll() {
   renderCalendarBoard();
   renderAvailability();
   renderDeadlinesAndReminders();
+  renderCoreReadiness();
   renderRevisedCalendar();
   renderProviderReadiness();
   renderPortalTimeline();

--- a/web/webportal/index.html
+++ b/web/webportal/index.html
@@ -82,6 +82,14 @@
 
     <section class="panel">
       <div class="section-title">
+        <p class="eyebrow">Calendar Status</p>
+        <h2>Revised Calendar Status</h2>
+      </div>
+      <div id="portal-revised-status" class="item-stack compact-list"></div>
+    </section>
+
+    <section class="panel">
+      <div class="section-title">
         <p class="eyebrow">Boundary</p>
         <h2>What This Portal Does</h2>
       </div>


### PR DESCRIPTION
## Summary
- Adds Native C scheduling-core contracts for schedule entry validation, deadline health, recurrence sandboxing, calendar-system labels, and revised-calendar rulepack readiness.
- Replaces implied final 13-month names with draft month labels and keeps conversion blocked until the owner-approved rulepack and conversion logic are supplied.
- Wires EPOCH App/Webportal local ledger views for native core readiness, recurrence candidates, deadline health, and customer-safe revised-calendar status.
- Updates docs and verifier coverage for the scheduling-core/rulepack boundary.

## Local MONITOR Note
- `D:\CITADEL\_control\scripts\hermes_persona_monitor.py` was patched outside this repo and regenerated so `epoch-monitor.html` reports native scheduling core readiness and revised-calendar conversion hold as operational status only.

## Verification
- `npm run verify`
- `cmake --build build --config Debug`
- `ctest --test-dir build -C Debug --output-on-failure`
- `python -m py_compile D:\CITADEL\_control\scripts\hermes_persona_monitor.py`
- `python D:\CITADEL\_control\scripts\hermes_persona_monitor.py --project EPOCH`
- Browser: EPOCH App shows core ready/rulepack held and no WORKSHOP revenue terms.
- Browser: EPOCH Webportal shows customer-safe revised-calendar status and no raw MONITOR controls.
- Browser: EPOCH MONITOR operating panel shows core/rulepack/recurrence rows and no product form controls.
- WORKSHOP regression: `npm run verify`, native build, and `ctest` passed.

Closes #82